### PR TITLE
CI: Fix dependabot

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'solana-program/record'
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository_owner == 'solana-program'
     steps:
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
#### Problem

The dependabot job runs on the exact repo, which works, but might be error-prone if we copy the file.

#### Summary of changes

Since this is a bit error-prone, use the `repository_owner` instead.