### PR TITLE
program: Mark test module `pub(crate)`

### DIFF
--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -32,7 +32,7 @@ impl IsInitialized for RecordData {
 }
 
 #[cfg(test)]
-pub mod tests {
+pub(crate) mod tests {
     use {super::*, solana_program_error::ProgramError};
 
     /// Version for tests


### PR DESCRIPTION
#### Problem

The downstream agave jobs are failing after the upgrade to Rust 1.84, because the lint for public modules needing documentation is getting tripped.

#### Summary of changes

Mark the test module as `pub(crate)` since it shouldn't be used outside.