### PR TITLE
[js-legacy] Add record program js-legacy client

### DIFF
--- a/clients/js-legacy/.mocharc.json
+++ b/clients/js-legacy/.mocharc.json
@@ -1,0 +1,10 @@
+{
+    "extension": [
+        "ts"
+    ],
+    "node-option": [
+        "experimental-specifier-resolution=node",
+        "loader=ts-node/esm"
+    ],
+    "timeout": 5000
+}

--- a/clients/js-legacy/README.md
+++ b/clients/js-legacy/README.md
@@ -1,0 +1,3 @@
+# @solana/record
+
+A TypeScript library for interacting with the record program.

--- a/clients/js-legacy/package.json
+++ b/clients/js-legacy/package.json
@@ -1,0 +1,37 @@
+{
+    "name": "@solana/record",
+    "description": "Record Program JS API",
+    "version": "0.1.0",
+    "repository": "https://github.com/solana-program/record",
+    "license": "Apache-2.0",
+    "type": "module",
+    "sideEffects": false,
+    "engines": {
+        "node": ">=16"
+    },
+    "files": [
+        "src"
+    ],
+    "scripts": {
+        "build": "tsc --build --verbose",
+        "lint": "eslint --max-warnings 0 .",
+        "lint:fix": "eslint --fix .",
+        "format": "prettier --check src test",
+        "format:fix": "prettier --write src test",
+        "test": "start-server-and-test 'solana-test-validator --bpf-program recr1L3PCGKLbckBqMNcJhuuyU1zgo8nBhfLVsJNwr5 ../../target/deploy/spl_record.so --reset --quiet' http://127.0.0.1:8899/health 'mocha test'"
+    },
+    "devDependencies": {
+        "@types/chai": "^5.0.1",
+        "@types/node": "^22.10.1",
+        "@types/mocha": "^10.0.10",
+        "@solana/web3.js": "^1.95.5",
+        "bigint-buffer": "^1.1.5",
+        "chai": "^5.1.2",
+        "mocha": "^11.0.1",
+        "prettier": "^3.4.2",
+        "typescript": "^5.7.2",
+        "start-server-and-test": "^2.0.8",
+        "ts-node": "^10.9.2"
+    },
+    "prettier": "@solana/prettier-config-solana"
+}

--- a/clients/js-legacy/package.json
+++ b/clients/js-legacy/package.json
@@ -27,7 +27,7 @@
         "@types/chai": "^5.0.1",
         "@types/node": "^22.10.1",
         "@types/mocha": "^10.0.10",
-        "bigint-buffer": "^1.1.5",
+        "@solana/codecs-numbers": "^2.0.0",
         "chai": "^5.1.2",
         "mocha": "^11.0.1",
         "prettier": "^3.4.2",

--- a/clients/js-legacy/package.json
+++ b/clients/js-legacy/package.json
@@ -23,11 +23,13 @@
     "peerDependencies": {
         "@solana/web3.js": "^1.95.5"
     },
+    "dependencies": {
+        "@solana/codecs-numbers": "^2.0.0"
+    },
     "devDependencies": {
         "@types/chai": "^5.0.1",
         "@types/node": "^22.10.1",
         "@types/mocha": "^10.0.10",
-        "@solana/codecs-numbers": "^2.0.0",
         "chai": "^5.1.2",
         "mocha": "^11.0.1",
         "prettier": "^3.4.2",

--- a/clients/js-legacy/package.json
+++ b/clients/js-legacy/package.json
@@ -20,11 +20,13 @@
         "format:fix": "prettier --write src test",
         "test": "start-server-and-test 'solana-test-validator --bpf-program recr1L3PCGKLbckBqMNcJhuuyU1zgo8nBhfLVsJNwr5 ../../target/deploy/spl_record.so --reset --quiet' http://127.0.0.1:8899/health 'mocha test'"
     },
+    "peerDependencies": {
+        "@solana/web3.js": "^1.95.5"
+    },
     "devDependencies": {
         "@types/chai": "^5.0.1",
         "@types/node": "^22.10.1",
         "@types/mocha": "^10.0.10",
-        "@solana/web3.js": "^1.95.5",
         "bigint-buffer": "^1.1.5",
         "chai": "^5.1.2",
         "mocha": "^11.0.1",

--- a/clients/js-legacy/package.json
+++ b/clients/js-legacy/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@solana/record",
+    "name": "@solana/spl-record",
     "description": "Record Program JS API",
     "version": "0.1.0",
     "repository": "https://github.com/solana-program/record",

--- a/clients/js-legacy/pnpm-lock.yaml
+++ b/clients/js-legacy/pnpm-lock.yaml
@@ -7,10 +7,14 @@ settings:
 importers:
 
   .:
-    devDependencies:
+    dependencies:
       '@solana/web3.js':
         specifier: ^1.95.5
         version: 1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    devDependencies:
+      '@solana/codecs-numbers':
+        specifier: ^2.0.0
+        version: 2.0.0(typescript@5.7.3)
       '@types/chai':
         specifier: ^5.0.1
         version: 5.0.1
@@ -20,9 +24,6 @@ importers:
       '@types/node':
         specifier: ^22.10.1
         version: 22.10.6
-      bigint-buffer:
-        specifier: ^1.1.5
-        version: 1.1.5
       chai:
         specifier: ^5.1.2
         version: 5.1.2
@@ -96,6 +97,25 @@ packages:
   '@solana/buffer-layout@4.0.1':
     resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
     engines: {node: '>=5.10'}
+
+  '@solana/codecs-core@2.0.0':
+    resolution: {integrity: sha512-qCG+3hDU5Pm8V6joJjR4j4Zv9md1z0RaecniNDIkEglnxmOUODnmPLWbtOjnDylfItyuZeDihK8hkewdj8cUtw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/codecs-numbers@2.0.0':
+    resolution: {integrity: sha512-r66i7VzJO1MZkQWZIAI6jjJOFVpnq0+FIabo2Z2ZDtrArFus/SbSEv543yCLeD2tdR/G/p+1+P5On10qF50Y1Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: '>=5'
+
+  '@solana/errors@2.0.0':
+    resolution: {integrity: sha512-IHlaPFSy4lvYco1oHJ3X8DbchWwAwJaL/4wZKnF1ugwZ0g0re8wbABrqNOe/jyZ84VU9Z14PYM8W9oDAebdJbw==}
+    engines: {node: '>=20.18.0'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5'
 
   '@solana/web3.js@1.98.0':
     resolution: {integrity: sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA==}
@@ -263,6 +283,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  chalk@5.4.1:
+    resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
@@ -288,6 +312,10 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -915,6 +943,23 @@ snapshots:
     dependencies:
       buffer: 6.0.3
 
+  '@solana/codecs-core@2.0.0(typescript@5.7.3)':
+    dependencies:
+      '@solana/errors': 2.0.0(typescript@5.7.3)
+      typescript: 5.7.3
+
+  '@solana/codecs-numbers@2.0.0(typescript@5.7.3)':
+    dependencies:
+      '@solana/codecs-core': 2.0.0(typescript@5.7.3)
+      '@solana/errors': 2.0.0(typescript@5.7.3)
+      typescript: 5.7.3
+
+  '@solana/errors@2.0.0(typescript@5.7.3)':
+    dependencies:
+      chalk: 5.4.1
+      commander: 12.1.0
+      typescript: 5.7.3
+
   '@solana/web3.js@1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
       '@babel/runtime': 7.26.0
@@ -1094,6 +1139,8 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  chalk@5.4.1: {}
+
   check-error@2.1.1: {}
 
   check-more-types@2.24.0: {}
@@ -1125,6 +1172,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  commander@12.1.0: {}
 
   commander@2.20.3: {}
 

--- a/clients/js-legacy/pnpm-lock.yaml
+++ b/clients/js-legacy/pnpm-lock.yaml
@@ -1,0 +1,1662 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@solana/web3.js':
+        specifier: ^1.95.5
+        version: 1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@types/chai':
+        specifier: ^5.0.1
+        version: 5.0.1
+      '@types/mocha':
+        specifier: ^10.0.10
+        version: 10.0.10
+      '@types/node':
+        specifier: ^22.10.1
+        version: 22.10.6
+      bigint-buffer:
+        specifier: ^1.1.5
+        version: 1.1.5
+      chai:
+        specifier: ^5.1.2
+        version: 5.1.2
+      mocha:
+        specifier: ^11.0.1
+        version: 11.0.1
+      prettier:
+        specifier: ^3.4.2
+        version: 3.4.2
+      start-server-and-test:
+        specifier: ^2.0.8
+        version: 2.0.10
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@22.10.6)(typescript@5.7.3)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.7.3
+
+packages:
+
+  '@babel/runtime@7.26.0':
+    resolution: {integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==}
+    engines: {node: '>=6.9.0'}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@hapi/hoek@9.3.0':
+    resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
+
+  '@hapi/topo@5.1.0':
+    resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.0':
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@noble/curves@1.8.0':
+    resolution: {integrity: sha512-j84kjAbzEnQHaSIhRPUmB3/eVXu2k3dKPl2LOrR8fSOIL+89U+7lV117EWHtq/GHM3ReGHM46iRBdZfpc4HRUQ==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.7.0':
+    resolution: {integrity: sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@sideway/address@4.1.5':
+    resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
+
+  '@sideway/formula@3.0.1':
+    resolution: {integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==}
+
+  '@sideway/pinpoint@2.0.0':
+    resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
+
+  '@solana/buffer-layout@4.0.1':
+    resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
+    engines: {node: '>=5.10'}
+
+  '@solana/web3.js@1.98.0':
+    resolution: {integrity: sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA==}
+
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tsconfig/node10@1.0.11':
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/chai@5.0.1':
+    resolution: {integrity: sha512-5T8ajsg3M/FOncpLYW7sdOcD6yf4+722sze/tc4KQV0P8Z2rAr3SAuHCIkYmYpt8VbcQlnz8SxlOlPQYefe4cA==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/mocha@10.0.10':
+    resolution: {integrity: sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q==}
+
+  '@types/node@12.20.55':
+    resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
+
+  '@types/node@22.10.6':
+    resolution: {integrity: sha512-qNiuwC4ZDAUNcY47xgaSuS92cjf8JbSUoaKS77bmLG1rU7MlATVSiw/IlrjtIyyskXBZ8KkNfjK/P5na7rgXbQ==}
+
+  '@types/uuid@8.3.4':
+    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
+
+  '@types/ws@7.4.7':
+    resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
+
+  '@types/ws@8.5.13':
+    resolution: {integrity: sha512-osM/gWBTPKgHV8XkTunnegTRIsvF6owmf5w+JtAfOw472dptdm0dlGv4xCt6GwQRcC2XVOvvRE/0bAoQcL2QkA==}
+
+  JSONStream@1.3.5:
+    resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
+    hasBin: true
+
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.14.0:
+    resolution: {integrity: sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+
+  ansi-colors@4.1.3:
+    resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
+    engines: {node: '>=6'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  axios@1.7.9:
+    resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  base-x@3.0.10:
+    resolution: {integrity: sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  bigint-buffer@1.1.5:
+    resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
+    engines: {node: '>= 10.0.0'}
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
+  bluebird@3.7.2:
+    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+
+  bn.js@5.2.1:
+    resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
+
+  borsh@0.7.0:
+    resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
+
+  brace-expansion@2.0.1:
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browser-stdout@1.3.1:
+    resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
+
+  bs58@4.0.1:
+    resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bufferutil@4.0.9:
+    resolution: {integrity: sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==}
+    engines: {node: '>=6.14.2'}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  chai@5.1.2:
+    resolution: {integrity: sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==}
+    engines: {node: '>=12'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
+
+  check-more-types@2.24.0:
+    resolution: {integrity: sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==}
+    engines: {node: '>= 0.8.0'}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.0:
+    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decamelize@4.0.0:
+    resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
+    engines: {node: '>=10'}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  delay@5.0.0:
+    resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
+    engines: {node: '>=10'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
+  diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+
+  diff@5.2.0:
+    resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
+    engines: {node: '>=0.3.1'}
+
+  duplexer@0.1.2:
+    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  es6-promise@4.2.8:
+    resolution: {integrity: sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==}
+
+  es6-promisify@5.0.0:
+    resolution: {integrity: sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==}
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  event-stream@3.3.4:
+    resolution: {integrity: sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==}
+
+  eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
+  eyes@0.1.8:
+    resolution: {integrity: sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==}
+    engines: {node: '> 0.1.90'}
+
+  fast-stable-stringify@1.0.0:
+    resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
+
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat@5.0.2:
+    resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
+    hasBin: true
+
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  foreground-child@3.3.0:
+    resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
+    engines: {node: '>=14'}
+
+  form-data@4.0.1:
+    resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
+    engines: {node: '>= 6'}
+
+  from@0.1.7:
+    resolution: {integrity: sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-plain-obj@2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isomorphic-ws@4.0.1:
+    resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
+    peerDependencies:
+      ws: '*'
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jayson@4.1.3:
+    resolution: {integrity: sha512-LtXh5aYZodBZ9Fc3j6f2w+MTNcnxteMOrb+QgIouguGOulWi0lieEkOUg+HkjjFs0DGoWDds6bi4E9hpNFLulQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  joi@17.13.3:
+    resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
+
+  js-yaml@4.1.0:
+    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+    hasBin: true
+
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
+  jsonparse@1.3.1:
+    resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
+    engines: {'0': node >= 0.2.0}
+
+  lazy-ass@1.6.0:
+    resolution: {integrity: sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==}
+    engines: {node: '> 0.8'}
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  log-symbols@4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
+
+  loupe@3.1.2:
+    resolution: {integrity: sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  map-stream@0.1.0:
+    resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
+
+  minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mocha@11.0.1:
+    resolution: {integrity: sha512-+3GkODfsDG71KSCQhc4IekSW+ItCK/kiez1Z28ksWvYhKXV/syxMlerR/sC7whDp7IyreZ4YxceMLdTs5hQE8A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  pathval@2.0.0:
+    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+    engines: {node: '>= 14.16'}
+
+  pause-stream@0.0.11:
+    resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
+
+  picomatch@2.3.1:
+    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+    engines: {node: '>=8.6'}
+
+  prettier@3.4.2:
+    resolution: {integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  ps-tree@1.2.0:
+    resolution: {integrity: sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==}
+    engines: {node: '>= 0.10'}
+    hasBin: true
+
+  randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
+  regenerator-runtime@0.14.1:
+    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  rpc-websockets@9.0.4:
+    resolution: {integrity: sha512-yWZWN0M+bivtoNLnaDbtny4XchdAIF5Q4g/ZsC5UC61Ckbp0QczwO8fg44rV3uYmY4WHd+EZQbn90W1d8ojzqQ==}
+
+  rxjs@7.8.1:
+    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  serialize-javascript@6.0.2:
+    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  split@0.3.3:
+    resolution: {integrity: sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==}
+
+  start-server-and-test@2.0.10:
+    resolution: {integrity: sha512-nZphcfcqGqwk74lbZkqSwClkYz+M5ZPGOMgWxNVJrdztPKN96qe6HooRu6L3TpwITn0lKJJdKACqHbJtqythOQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  stream-combiner@0.0.4:
+    resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
+  strip-json-comments@3.1.1:
+    resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
+    engines: {node: '>=8'}
+
+  superstruct@2.0.2:
+    resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
+    engines: {node: '>=14.0.0'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
+
+  text-encoding-utf-8@1.0.2:
+    resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
+
+  through@2.3.8:
+    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.7.3:
+    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
+  utf-8-validate@5.0.10:
+    resolution: {integrity: sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==}
+    engines: {node: '>=6.14.2'}
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  wait-on@8.0.2:
+    resolution: {integrity: sha512-qHlU6AawrgAIHlueGQHQ+ETcPLAauXbnoTKl3RKq20W0T8x0DKVAo5xWIYjHSyvHxQlcYbFdR0jp4T9bDVITFA==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  workerpool@6.5.1:
+    resolution: {integrity: sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  ws@7.5.10:
+    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.18.0:
+    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
+  yargs-unparser@2.0.0:
+    resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
+    engines: {node: '>=10'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
+snapshots:
+
+  '@babel/runtime@7.26.0':
+    dependencies:
+      regenerator-runtime: 0.14.1
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@hapi/hoek@9.3.0': {}
+
+  '@hapi/topo@5.1.0':
+    dependencies:
+      '@hapi/hoek': 9.3.0
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@noble/curves@1.8.0':
+    dependencies:
+      '@noble/hashes': 1.7.0
+
+  '@noble/hashes@1.7.0': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@sideway/address@4.1.5':
+    dependencies:
+      '@hapi/hoek': 9.3.0
+
+  '@sideway/formula@3.0.1': {}
+
+  '@sideway/pinpoint@2.0.0': {}
+
+  '@solana/buffer-layout@4.0.1':
+    dependencies:
+      buffer: 6.0.3
+
+  '@solana/web3.js@1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@noble/curves': 1.8.0
+      '@noble/hashes': 1.7.0
+      '@solana/buffer-layout': 4.0.1
+      agentkeepalive: 4.6.0
+      bigint-buffer: 1.1.5
+      bn.js: 5.2.1
+      borsh: 0.7.0
+      bs58: 4.0.1
+      buffer: 6.0.3
+      fast-stable-stringify: 1.0.0
+      jayson: 4.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      node-fetch: 2.7.0
+      rpc-websockets: 9.0.4
+      superstruct: 2.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+
+  '@tsconfig/node10@1.0.11': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
+
+  '@types/chai@5.0.1':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.10.6
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/mocha@10.0.10': {}
+
+  '@types/node@12.20.55': {}
+
+  '@types/node@22.10.6':
+    dependencies:
+      undici-types: 6.20.0
+
+  '@types/uuid@8.3.4': {}
+
+  '@types/ws@7.4.7':
+    dependencies:
+      '@types/node': 22.10.6
+
+  '@types/ws@8.5.13':
+    dependencies:
+      '@types/node': 22.10.6
+
+  JSONStream@1.3.5:
+    dependencies:
+      jsonparse: 1.3.1
+      through: 2.3.8
+
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.14.0
+
+  acorn@8.14.0: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
+
+  ansi-colors@4.1.3: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.1.0: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.1: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.1
+
+  arg@4.1.3: {}
+
+  arg@5.0.2: {}
+
+  argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  asynckit@0.4.0: {}
+
+  axios@1.7.9(debug@4.4.0):
+    dependencies:
+      follow-redirects: 1.15.9(debug@4.4.0)
+      form-data: 4.0.1
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
+  balanced-match@1.0.2: {}
+
+  base-x@3.0.10:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  base64-js@1.5.1: {}
+
+  bigint-buffer@1.1.5:
+    dependencies:
+      bindings: 1.5.0
+
+  binary-extensions@2.3.0: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
+  bluebird@3.7.2: {}
+
+  bn.js@5.2.1: {}
+
+  borsh@0.7.0:
+    dependencies:
+      bn.js: 5.2.1
+      bs58: 4.0.1
+      text-encoding-utf-8: 1.0.2
+
+  brace-expansion@2.0.1:
+    dependencies:
+      balanced-match: 1.0.2
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browser-stdout@1.3.1: {}
+
+  bs58@4.0.1:
+    dependencies:
+      base-x: 3.0.10
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  bufferutil@4.0.9:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
+  camelcase@6.3.0: {}
+
+  chai@5.1.2:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.2
+      pathval: 2.0.0
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  check-error@2.1.1: {}
+
+  check-more-types@2.24.0: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
+  commander@2.20.3: {}
+
+  create-require@1.1.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.0(supports-color@8.1.1):
+    dependencies:
+      ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
+
+  decamelize@4.0.0: {}
+
+  deep-eql@5.0.2: {}
+
+  delay@5.0.0: {}
+
+  delayed-stream@1.0.0: {}
+
+  diff@4.0.2: {}
+
+  diff@5.2.0: {}
+
+  duplexer@0.1.2: {}
+
+  eastasianwidth@0.2.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  es6-promise@4.2.8: {}
+
+  es6-promisify@5.0.0:
+    dependencies:
+      es6-promise: 4.2.8
+
+  escalade@3.2.0: {}
+
+  escape-string-regexp@4.0.0: {}
+
+  event-stream@3.3.4:
+    dependencies:
+      duplexer: 0.1.2
+      from: 0.1.7
+      map-stream: 0.1.0
+      pause-stream: 0.0.11
+      split: 0.3.3
+      stream-combiner: 0.0.4
+      through: 2.3.8
+
+  eventemitter3@5.0.1: {}
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  eyes@0.1.8: {}
+
+  fast-stable-stringify@1.0.0: {}
+
+  file-uri-to-path@1.0.0: {}
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat@5.0.2: {}
+
+  follow-redirects@1.15.9(debug@4.4.0):
+    optionalDependencies:
+      debug: 4.4.0(supports-color@8.1.1)
+
+  foreground-child@3.3.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  form-data@4.0.1:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+
+  from@0.1.7: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-caller-file@2.0.5: {}
+
+  get-stream@6.0.1: {}
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.0
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  has-flag@4.0.0: {}
+
+  he@1.2.0: {}
+
+  human-signals@2.1.0: {}
+
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+
+  ieee754@1.2.1: {}
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  is-plain-obj@2.1.0: {}
+
+  is-stream@2.0.1: {}
+
+  is-unicode-supported@0.1.0: {}
+
+  isexe@2.0.0: {}
+
+  isomorphic-ws@4.0.1(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+    dependencies:
+      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  jayson@4.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 12.20.55
+      '@types/ws': 7.4.7
+      JSONStream: 1.3.5
+      commander: 2.20.3
+      delay: 5.0.0
+      es6-promisify: 5.0.0
+      eyes: 0.1.8
+      isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      json-stringify-safe: 5.0.1
+      uuid: 8.3.2
+      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  joi@17.13.3:
+    dependencies:
+      '@hapi/hoek': 9.3.0
+      '@hapi/topo': 5.1.0
+      '@sideway/address': 4.1.5
+      '@sideway/formula': 3.0.1
+      '@sideway/pinpoint': 2.0.0
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-stringify-safe@5.0.1: {}
+
+  jsonparse@1.3.1: {}
+
+  lazy-ass@1.6.0: {}
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash@4.17.21: {}
+
+  log-symbols@4.1.0:
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
+
+  loupe@3.1.2: {}
+
+  lru-cache@10.4.3: {}
+
+  make-error@1.3.6: {}
+
+  map-stream@0.1.0: {}
+
+  merge-stream@2.0.0: {}
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mimic-fn@2.1.0: {}
+
+  minimatch@5.1.6:
+    dependencies:
+      brace-expansion: 2.0.1
+
+  minimatch@9.0.5:
+    dependencies:
+      brace-expansion: 2.0.1
+
+  minimist@1.2.8: {}
+
+  minipass@7.1.2: {}
+
+  mocha@11.0.1:
+    dependencies:
+      ansi-colors: 4.1.3
+      browser-stdout: 1.3.1
+      chokidar: 3.6.0
+      debug: 4.4.0(supports-color@8.1.1)
+      diff: 5.2.0
+      escape-string-regexp: 4.0.0
+      find-up: 5.0.0
+      glob: 10.4.5
+      he: 1.2.0
+      js-yaml: 4.1.0
+      log-symbols: 4.1.0
+      minimatch: 5.1.6
+      ms: 2.1.3
+      serialize-javascript: 6.0.2
+      strip-json-comments: 3.1.1
+      supports-color: 8.1.1
+      workerpool: 6.5.1
+      yargs: 16.2.0
+      yargs-parser: 20.2.9
+      yargs-unparser: 2.0.0
+
+  ms@2.1.3: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-gyp-build@4.8.4:
+    optional: true
+
+  normalize-path@3.0.0: {}
+
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  package-json-from-dist@1.0.1: {}
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
+
+  pathval@2.0.0: {}
+
+  pause-stream@0.0.11:
+    dependencies:
+      through: 2.3.8
+
+  picomatch@2.3.1: {}
+
+  prettier@3.4.2: {}
+
+  proxy-from-env@1.1.0: {}
+
+  ps-tree@1.2.0:
+    dependencies:
+      event-stream: 3.3.4
+
+  randombytes@2.1.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.1
+
+  regenerator-runtime@0.14.1: {}
+
+  require-directory@2.1.1: {}
+
+  rpc-websockets@9.0.4:
+    dependencies:
+      '@swc/helpers': 0.5.15
+      '@types/uuid': 8.3.4
+      '@types/ws': 8.5.13
+      buffer: 6.0.3
+      eventemitter3: 5.0.1
+      uuid: 8.3.2
+      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      bufferutil: 4.0.9
+      utf-8-validate: 5.0.10
+
+  rxjs@7.8.1:
+    dependencies:
+      tslib: 2.8.1
+
+  safe-buffer@5.2.1: {}
+
+  serialize-javascript@6.0.2:
+    dependencies:
+      randombytes: 2.1.0
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@3.0.7: {}
+
+  signal-exit@4.1.0: {}
+
+  split@0.3.3:
+    dependencies:
+      through: 2.3.8
+
+  start-server-and-test@2.0.10:
+    dependencies:
+      arg: 5.0.2
+      bluebird: 3.7.2
+      check-more-types: 2.24.0
+      debug: 4.4.0(supports-color@8.1.1)
+      execa: 5.1.1
+      lazy-ass: 1.6.0
+      ps-tree: 1.2.0
+      wait-on: 8.0.2(debug@4.4.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  stream-combiner@0.0.4:
+    dependencies:
+      duplexer: 0.1.2
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.1.0:
+    dependencies:
+      ansi-regex: 6.1.0
+
+  strip-final-newline@2.0.0: {}
+
+  strip-json-comments@3.1.1: {}
+
+  superstruct@2.0.2: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
+  text-encoding-utf-8@1.0.2: {}
+
+  through@2.3.8: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  tr46@0.0.3: {}
+
+  ts-node@10.9.2(@types/node@22.10.6)(typescript@5.7.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.10.6
+      acorn: 8.14.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.7.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  tslib@2.8.1: {}
+
+  typescript@5.7.3: {}
+
+  undici-types@6.20.0: {}
+
+  utf-8-validate@5.0.10:
+    dependencies:
+      node-gyp-build: 4.8.4
+    optional: true
+
+  uuid@8.3.2: {}
+
+  v8-compile-cache-lib@3.0.1: {}
+
+  wait-on@8.0.2(debug@4.4.0):
+    dependencies:
+      axios: 1.7.9(debug@4.4.0)
+      joi: 17.13.3
+      lodash: 4.17.21
+      minimist: 1.2.8
+      rxjs: 7.8.1
+    transitivePeerDependencies:
+      - debug
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  workerpool@6.5.1: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+
+  ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.9
+      utf-8-validate: 5.0.10
+
+  ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.9
+      utf-8-validate: 5.0.10
+
+  y18n@5.0.8: {}
+
+  yargs-parser@20.2.9: {}
+
+  yargs-unparser@2.0.0:
+    dependencies:
+      camelcase: 6.3.0
+      decamelize: 4.0.0
+      flat: 5.0.2
+      is-plain-obj: 2.1.0
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
+
+  yn@3.1.1: {}
+
+  yocto-queue@0.1.0: {}

--- a/clients/js-legacy/pnpm-lock.yaml
+++ b/clients/js-legacy/pnpm-lock.yaml
@@ -8,13 +8,13 @@ importers:
 
   .:
     dependencies:
+      '@solana/codecs-numbers':
+        specifier: ^2.0.0
+        version: 2.0.0(typescript@5.7.3)
       '@solana/web3.js':
         specifier: ^1.95.5
         version: 1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     devDependencies:
-      '@solana/codecs-numbers':
-        specifier: ^2.0.0
-        version: 2.0.0(typescript@5.7.3)
       '@types/chai':
         specifier: ^5.0.1
         version: 5.0.1

--- a/clients/js-legacy/src/actions.ts
+++ b/clients/js-legacy/src/actions.ts
@@ -79,9 +79,8 @@ export async function writeRecord(
 ) {
     let transactionResults = [];
     let bufferOffset = 0;
-    let remainingBuffer = buffer;
-    while (bufferOffset < remainingBuffer.length) {
-        const currentChunkBuffer = remainingBuffer.subarray(
+    while (bufferOffset < buffer.length) {
+        const currentChunkBuffer = buffer.subarray(
             bufferOffset,
             bufferOffset + RECORD_CHUNK_SIZE_POST_INITIALIZE
         );

--- a/clients/js-legacy/src/actions.ts
+++ b/clients/js-legacy/src/actions.ts
@@ -19,7 +19,7 @@ import {
  *
  * @param connection      Connection to use
  * @param payer           Payer of the transaction fees
- * @param record          Record account address
+ * @param record          Record account signer
  * @param authority       Record account authority
  * @param recordSize      Size of the record to be stored
  * @param confirmOptions  Options for confirming the transaction
@@ -104,7 +104,7 @@ export async function writeRecord(
  *
  * @param connection      Connection to use
  * @param payer           Payer of the transaction fees
- * @param record          Record account address
+ * @param record          Record account signer
  * @param authority       Record account authority keypair
  * @param recordSize      Offset to store the record bytes
  * @param buffer          Record bytes

--- a/clients/js-legacy/src/actions.ts
+++ b/clients/js-legacy/src/actions.ts
@@ -65,7 +65,7 @@ export async function createRecord(
  * @param buffer          Record bytes
  * @param confirmOptions  Options for confirming the transaction
  *
- * @return Signature of the confirmed transaction
+ * @return Signatures of the confirmed transaction
  */
 export async function writeRecord(
     connection: Connection,
@@ -110,7 +110,7 @@ export async function writeRecord(
  * @param buffer          Record bytes
  * @param confirmOptions  Options for confirming the transaction
  *
- * @return Signature of the confirmed transaction
+ * @return Signatures of the confirmed transaction
  */
 export async function createInitializeWriteRecord(
     connection: Connection,

--- a/clients/js-legacy/src/actions.ts
+++ b/clients/js-legacy/src/actions.ts
@@ -26,7 +26,7 @@ import {
  *
  * @return Signature of the confirmed transaction
  */
-export async function initializeRecord(
+export async function createRecord(
     connection: Connection,
     payer: Signer,
     record: Signer,
@@ -110,7 +110,7 @@ export async function writeRecord(
  *
  * @return Signature of the confirmed transaction
  */
-export async function initializeWriteRecord(
+export async function createInitializeWriteRecord(
     connection: Connection,
     payer: Signer,
     record: Signer,

--- a/clients/js-legacy/src/actions.ts
+++ b/clients/js-legacy/src/actions.ts
@@ -33,8 +33,8 @@ export async function createRecord(
     authority: PublicKey,
     recordSize: number,
     confirmOptions?: ConfirmOptions,
+    programId = RECORD_PROGRAM_ID,
 ) {
-    const programId = RECORD_PROGRAM_ID;
     const recordAccountSize = RECORD_META_DATA_SIZE + recordSize;
     const lamports = await connection.getMinimumBalanceForRentExemption(Number(recordAccountSize));
     const transaction = new Transaction().add(
@@ -48,6 +48,7 @@ export async function createRecord(
         createInitializeInstruction(
             record.publicKey,
             authority,
+            programId,
         )
     );
     return await sendAndConfirmTransaction(connection, transaction, [payer, record], confirmOptions);
@@ -74,6 +75,7 @@ export async function writeRecord(
     offset: number,
     buffer: Uint8Array,
     confirmOptions?: ConfirmOptions,
+    programId = RECORD_PROGRAM_ID,
 ) {
     let transactionResults = [];
     let bufferOffset = 0;
@@ -89,6 +91,7 @@ export async function writeRecord(
                 authority.publicKey,
                 offset + bufferOffset,
                 currentChunkBuffer,
+                programId,
             )
         );
         transactionResults.push(sendAndConfirmTransaction(connection, transaction, [payer, authority], confirmOptions));
@@ -118,8 +121,8 @@ export async function createInitializeWriteRecord(
     offset: number,
     buffer: Uint8Array,
     confirmOptions?: ConfirmOptions,
+    programId = RECORD_PROGRAM_ID,
 ) {
-    const programId = RECORD_PROGRAM_ID;
     const recordSize = buffer.length;
     const recordAccountSize = RECORD_META_DATA_SIZE + recordSize;
     const lamports = await connection.getMinimumBalanceForRentExemption(recordAccountSize);
@@ -135,12 +138,14 @@ export async function createInitializeWriteRecord(
         createInitializeInstruction(
             record.publicKey,
             authority.publicKey,
+            programId,
         ),
         createWriteInstruction(
             record.publicKey,
             authority.publicKey,
             offset,
             firstChunkBuffer,
+            programId,
         )
     );
     await sendAndConfirmTransaction(connection, transaction, [payer, authority, record], confirmOptions);
@@ -156,6 +161,7 @@ export async function createInitializeWriteRecord(
             newOffset,
             remainingChunkBuffer,
             confirmOptions,
+            programId,
         );
     }
 }
@@ -179,12 +185,14 @@ export async function setAuthority(
     currentAuthority: Signer,
     newAuthority: PublicKey,
     confirmOptions?: ConfirmOptions,
+    programId = RECORD_PROGRAM_ID,
 ) {
     const transaction = new Transaction().add(
         createSetAuthorityInstruction(
             record,
             currentAuthority.publicKey,
             newAuthority,
+            programId,
         )
     );
     return await sendAndConfirmTransaction(connection, transaction, [payer, currentAuthority], confirmOptions);
@@ -209,12 +217,14 @@ export async function closeRecord(
     authority: Signer,
     receiver: PublicKey,
     confirmOptions?: ConfirmOptions,
+    programId = RECORD_PROGRAM_ID,
 ) {
     const transaction = new Transaction().add(
         createCloseAccountInstruction(
             record,
             authority.publicKey,
             receiver,
+            programId,
         )
     );
     return await sendAndConfirmTransaction(connection, transaction, [payer, authority], confirmOptions);
@@ -241,6 +251,7 @@ export async function reallocateRecord(
     dataLength: number,
     fundAccount: boolean,
     confirmOptions?: ConfirmOptions,
+    programId = RECORD_PROGRAM_ID,
 ) {
     let transaction = new Transaction();
     if (fundAccount) {
@@ -266,6 +277,7 @@ export async function reallocateRecord(
             record,
             authority.publicKey,
             dataLength,
+            programId,
         )
     );
     return await sendAndConfirmTransaction(connection, transaction, [payer, authority], confirmOptions);

--- a/clients/js-legacy/src/actions.ts
+++ b/clients/js-legacy/src/actions.ts
@@ -31,11 +31,11 @@ export async function createRecord(
     payer: Signer,
     record: Signer,
     authority: PublicKey,
-    recordSize: number,
+    recordSize: bigint,
     confirmOptions?: ConfirmOptions,
     programId = RECORD_PROGRAM_ID,
 ) {
-    const recordAccountSize = RECORD_META_DATA_SIZE + recordSize;
+    const recordAccountSize = BigInt(RECORD_META_DATA_SIZE) + recordSize;
     const lamports = await connection.getMinimumBalanceForRentExemption(Number(recordAccountSize));
     const transaction = new Transaction().add(
         SystemProgram.createAccount({
@@ -72,7 +72,7 @@ export async function writeRecord(
     payer: Signer,
     record: PublicKey,
     authority: Signer,
-    offset: number,
+    offset: bigint,
     buffer: Uint8Array,
     confirmOptions?: ConfirmOptions,
     programId = RECORD_PROGRAM_ID,
@@ -88,7 +88,7 @@ export async function writeRecord(
             createWriteInstruction(
                 record,
                 authority.publicKey,
-                offset + bufferOffset,
+                offset + BigInt(bufferOffset),
                 currentChunkBuffer,
                 programId,
             )
@@ -117,7 +117,7 @@ export async function createInitializeWriteRecord(
     payer: Signer,
     record: Signer,
     authority: Signer,
-    offset: number,
+    offset: bigint,
     buffer: Uint8Array,
     confirmOptions?: ConfirmOptions,
     programId = RECORD_PROGRAM_ID,
@@ -155,7 +155,7 @@ export async function createInitializeWriteRecord(
     );
 
     if (buffer.length > RECORD_CHUNK_SIZE_PRE_INITIALIZE) {
-        const newOffset = offset + RECORD_CHUNK_SIZE_PRE_INITIALIZE;
+        const newOffset = offset + BigInt(RECORD_CHUNK_SIZE_PRE_INITIALIZE);
         const remainingChunkBuffer = buffer.subarray(RECORD_CHUNK_SIZE_PRE_INITIALIZE);
         return await writeRecord(
             connection,
@@ -254,7 +254,7 @@ export async function reallocateRecord(
     payer: Signer,
     record: PublicKey,
     authority: Signer,
-    dataLength: number,
+    dataLength: bigint,
     fundAccount: boolean,
     confirmOptions?: ConfirmOptions,
     programId = RECORD_PROGRAM_ID,
@@ -262,8 +262,8 @@ export async function reallocateRecord(
     let transaction = new Transaction();
     if (fundAccount) {
         const currentLamports = await connection.getBalance(record);
-        const newAccountSize = RECORD_META_DATA_SIZE + dataLength;
-        const newAccountLamports = await connection.getMinimumBalanceForRentExemption(newAccountSize);
+        const newAccountSize = dataLength + BigInt(RECORD_META_DATA_SIZE);
+        const newAccountLamports = await connection.getMinimumBalanceForRentExemption(Number(newAccountSize));
 
         if (currentLamports < newAccountLamports) {
             const neededLamports = newAccountLamports - currentLamports;

--- a/clients/js-legacy/src/actions.ts
+++ b/clients/js-legacy/src/actions.ts
@@ -1,0 +1,272 @@
+import type { ConfirmOptions, Connection, Signer } from '@solana/web3.js';
+import { PublicKey, sendAndConfirmTransaction, SystemProgram, Transaction } from '@solana/web3.js';
+import {
+    RECORD_PROGRAM_ID,
+    RECORD_META_DATA_SIZE,
+    RECORD_CHUNK_SIZE_PRE_INITIALIZE,
+    RECORD_CHUNK_SIZE_POST_INITIALIZE,
+} from './constants';
+import {
+    createInitializeInstruction,
+    createWriteInstruction,
+    createSetAuthorityInstruction,
+    createCloseAccountInstruction,
+    createReallocateInstruction,
+} from './instructions';
+
+/**
+ * Initialize a record account
+ *
+ * @param connection      Connection to use
+ * @param payer           Payer of the transaction fees
+ * @param record          Record account address
+ * @param authority       Record account authority
+ * @param recordSize      Size of the record to be stored
+ * @param confirmOptions  Options for confirming the transaction
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function initializeRecord(
+    connection: Connection,
+    payer: Signer,
+    record: Signer,
+    authority: PublicKey,
+    recordSize: number,
+    confirmOptions?: ConfirmOptions,
+) {
+    const programId = RECORD_PROGRAM_ID;
+    const recordAccountSize = RECORD_META_DATA_SIZE + recordSize;
+    const lamports = await connection.getMinimumBalanceForRentExemption(Number(recordAccountSize));
+    const transaction = new Transaction().add(
+        SystemProgram.createAccount({
+            fromPubkey: payer.publicKey,
+            newAccountPubkey: record.publicKey,
+            space: Number(recordAccountSize),
+            lamports,
+            programId,
+        }),
+        createInitializeInstruction(
+            record.publicKey,
+            authority,
+        )
+    );
+    return await sendAndConfirmTransaction(connection, transaction, [payer, record], confirmOptions);
+}
+
+/**
+ * Write to an initialized record account
+ *
+ * @param connection      Connection to use
+ * @param payer           Payer of the transaction fees
+ * @param record          Record account address
+ * @param authority       Record account authority keypair
+ * @param recordSize      Offset to store the record bytes
+ * @param buffer          Record bytes
+ * @param confirmOptions  Options for confirming the transaction
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function writeRecord(
+    connection: Connection,
+    payer: Signer,
+    record: PublicKey,
+    authority: Signer,
+    offset: number,
+    buffer: Uint8Array,
+    confirmOptions?: ConfirmOptions,
+) {
+    let transactionResults = [];
+    let bufferOffset = 0;
+    let remainingBuffer = buffer;
+    while (bufferOffset < remainingBuffer.length) {
+        const currentChunkBuffer = remainingBuffer.subarray(
+            bufferOffset,
+            bufferOffset + RECORD_CHUNK_SIZE_POST_INITIALIZE
+        );
+        const transaction = new Transaction().add(
+            createWriteInstruction(
+                record,
+                authority.publicKey,
+                offset + bufferOffset,
+                currentChunkBuffer,
+            )
+        );
+        transactionResults.push(sendAndConfirmTransaction(connection, transaction, [payer, authority], confirmOptions));
+        bufferOffset = bufferOffset + RECORD_CHUNK_SIZE_POST_INITIALIZE;
+    }
+    return await Promise.all(transactionResults);
+}
+
+/**
+ * Initialize and write to a record account
+ *
+ * @param connection      Connection to use
+ * @param payer           Payer of the transaction fees
+ * @param record          Record account address
+ * @param authority       Record account authority keypair
+ * @param recordSize      Offset to store the record bytes
+ * @param buffer          Record bytes
+ * @param confirmOptions  Options for confirming the transaction
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function initializeWriteRecord(
+    connection: Connection,
+    payer: Signer,
+    record: Signer,
+    authority: Signer,
+    offset: number,
+    buffer: Uint8Array,
+    confirmOptions?: ConfirmOptions,
+) {
+    const programId = RECORD_PROGRAM_ID;
+    const recordSize = buffer.length;
+    const recordAccountSize = RECORD_META_DATA_SIZE + recordSize;
+    const lamports = await connection.getMinimumBalanceForRentExemption(recordAccountSize);
+    const firstChunkBuffer = buffer.subarray(0, RECORD_CHUNK_SIZE_PRE_INITIALIZE);
+    const transaction = new Transaction().add(
+        SystemProgram.createAccount({
+            fromPubkey: payer.publicKey,
+            newAccountPubkey: record.publicKey,
+            space: recordAccountSize,
+            lamports,
+            programId,
+        }),
+        createInitializeInstruction(
+            record.publicKey,
+            authority.publicKey,
+        ),
+        createWriteInstruction(
+            record.publicKey,
+            authority.publicKey,
+            offset,
+            firstChunkBuffer,
+        )
+    );
+    await sendAndConfirmTransaction(connection, transaction, [payer, authority, record], confirmOptions);
+
+    if (buffer.length > RECORD_CHUNK_SIZE_PRE_INITIALIZE) {
+        const newOffset = offset + RECORD_CHUNK_SIZE_PRE_INITIALIZE;
+        const remainingChunkBuffer = buffer.subarray(RECORD_CHUNK_SIZE_PRE_INITIALIZE);
+        return await writeRecord(
+            connection,
+            payer,
+            record.publicKey,
+            authority,
+            newOffset,
+            remainingChunkBuffer,
+            confirmOptions,
+        );
+    }
+}
+
+/**
+ * Set a new authority for a record account
+ *
+ * @param connection        Connection to use
+ * @param payer             Payer of the transaction fees
+ * @param record            Record account address
+ * @param currentAuthority  Current record account authority
+ * @param newAuthority      New record account authority
+ * @param confirmOptions    Options for confirming the transaction
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function setAuthority(
+    connection: Connection,
+    payer: Signer,
+    record: PublicKey,
+    currentAuthority: Signer,
+    newAuthority: PublicKey,
+    confirmOptions?: ConfirmOptions,
+) {
+    const transaction = new Transaction().add(
+        createSetAuthorityInstruction(
+            record,
+            currentAuthority.publicKey,
+            newAuthority,
+        )
+    );
+    return await sendAndConfirmTransaction(connection, transaction, [payer, currentAuthority], confirmOptions);
+}
+
+/**
+ * Close a record account
+ *
+ * @param connection      Connection to use
+ * @param payer           Payer of the transaction fees
+ * @param record          Record account address
+ * @param authority       Record account authority keypair
+ * @param receiver        Receiving account for lamports
+ * @param confirmOptions  Options for confirming the transaction
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function closeRecord(
+    connection: Connection,
+    payer: Signer,
+    record: PublicKey,
+    authority: Signer,
+    receiver: PublicKey,
+    confirmOptions?: ConfirmOptions,
+) {
+    const transaction = new Transaction().add(
+        createCloseAccountInstruction(
+            record,
+            authority.publicKey,
+            receiver,
+        )
+    );
+    return await sendAndConfirmTransaction(connection, transaction, [payer, authority], confirmOptions);
+}
+
+/**
+ * Reallocate a record account to a new size
+ *
+ * @param connection      Connection to use
+ * @param payer           Payer of the transaction fees
+ * @param record          Record account address
+ * @param authority       Record account authority keypair
+ * @param dataLength      New record length to be stored in the account
+ * @param fundAccount     If true, fund the account if needed
+ * @param confirmOptions  Options for confirming the transaction
+ *
+ * @return Signature of the confirmed transaction
+ */
+export async function reallocateRecord(
+    connection: Connection,
+    payer: Signer,
+    record: PublicKey,
+    authority: Signer,
+    dataLength: number,
+    fundAccount: boolean,
+    confirmOptions?: ConfirmOptions,
+) {
+    let transaction = new Transaction();
+    if (fundAccount) {
+        const currentLamports = await connection.getBalance(record);
+        const newAccountSize = RECORD_META_DATA_SIZE + dataLength;
+        const newAccountLamports = await connection.getMinimumBalanceForRentExemption(newAccountSize);
+
+        if (currentLamports < newAccountLamports) {
+            const neededLamports = newAccountLamports - currentLamports;
+            transaction.add(
+                SystemProgram.transfer({
+                    fromPubkey: payer.publicKey,
+                    toPubkey: record,
+                    lamports: neededLamports,
+                })
+            );
+        } else {
+            console.log("no additional funds needed for space")
+        }
+    }
+    transaction.add(
+        createReallocateInstruction(
+            record,
+            authority.publicKey,
+            dataLength,
+        )
+    );
+    return await sendAndConfirmTransaction(connection, transaction, [payer, authority], confirmOptions);
+}

--- a/clients/js-legacy/src/actions.ts
+++ b/clients/js-legacy/src/actions.ts
@@ -147,7 +147,12 @@ export async function createInitializeWriteRecord(
             programId,
         )
     );
-    await sendAndConfirmTransaction(connection, transaction, [payer, authority, record], confirmOptions);
+    const signature = await sendAndConfirmTransaction(
+        connection,
+        transaction,
+        [payer, authority, record],
+        confirmOptions
+    );
 
     if (buffer.length > RECORD_CHUNK_SIZE_PRE_INITIALIZE) {
         const newOffset = offset + RECORD_CHUNK_SIZE_PRE_INITIALIZE;
@@ -162,6 +167,8 @@ export async function createInitializeWriteRecord(
             confirmOptions,
             programId,
         );
+    } else {
+        return [signature];
     }
 }
 

--- a/clients/js-legacy/src/constants.ts
+++ b/clients/js-legacy/src/constants.ts
@@ -1,0 +1,10 @@
+import { PublicKey } from '@solana/web3.js';
+
+export const RECORD_PROGRAM_ID = new PublicKey('recr1L3PCGKLbckBqMNcJhuuyU1zgo8nBhfLVsJNwr5');
+
+/** A record account size excluding the record payload */
+export const RECORD_META_DATA_SIZE = 33;
+/** Maximum record chunk that can fit inside a transaction when initializing a record account */
+export const RECORD_CHUNK_SIZE_PRE_INITIALIZE = 696;
+/** Maximum record chunk that can fit inside a transaction when record account already initialized */
+export const RECORD_CHUNK_SIZE_POST_INITIALIZE = 919;

--- a/clients/js-legacy/src/index.ts
+++ b/clients/js-legacy/src/index.ts
@@ -1,0 +1,4 @@
+export * from './actions.js';
+export * from './constants.js';
+export * from './instructions.js';
+export * from './state.js';

--- a/clients/js-legacy/src/instructions.ts
+++ b/clients/js-legacy/src/instructions.ts
@@ -21,12 +21,12 @@ export enum RecordInstruction {
 export function createInitializeInstruction(
     record: PublicKey,
     authority: PublicKey,
+    programId = RECORD_PROGRAM_ID,
 ) {
     const keys = [
         { pubkey: record, isSigner: false, isWritable: true },
         { pubkey: authority, isSigner: false, isWritable: false },
     ];
-    const programId = RECORD_PROGRAM_ID;
     const data = Buffer.from([RecordInstruction.Initialize]);
 
     return new TransactionInstruction({ keys, programId, data });
@@ -47,12 +47,12 @@ export function createWriteInstruction(
     authority: PublicKey,
     offset: number,
     buffer: Uint8Array,
+    programId = RECORD_PROGRAM_ID,
 ) {
     const keys = [
         { pubkey: record, isSigner: false, isWritable: true },
         { pubkey: authority, isSigner: true, isWritable: false },
     ]
-    const programId = RECORD_PROGRAM_ID;
     const bufferLength = BigInt(buffer.length);
     const data = Buffer.from([
         RecordInstruction.Write,
@@ -77,13 +77,13 @@ export function createSetAuthorityInstruction(
     record: PublicKey,
     currentAuthority: PublicKey,
     newAuthority: PublicKey,
+    programId = RECORD_PROGRAM_ID,
 ) {
     const keys = [
         { pubkey: record, isSigner: false, isWritable: true },
         { pubkey: currentAuthority, isSigner: true, isWritable: false },
         { pubkey: newAuthority, isSigner: false, isWritable: false },
     ]
-    const programId = RECORD_PROGRAM_ID;
     const data = Buffer.from([RecordInstruction.SetAuthority]);
 
     return new TransactionInstruction({ keys, programId, data });
@@ -102,13 +102,13 @@ export function createCloseAccountInstruction(
     record: PublicKey,
     authority: PublicKey,
     receiver: PublicKey,
+    programId = RECORD_PROGRAM_ID,
 ) {
     const keys = [
         { pubkey: record, isSigner: false, isWritable: true },
         { pubkey: authority, isSigner: true, isWritable: false },
         { pubkey: receiver, isSigner: false, isWritable: true },
     ]
-    const programId = RECORD_PROGRAM_ID;
     const data = Buffer.from([RecordInstruction.CloseAccount]);
 
     return new TransactionInstruction({ keys, programId, data });
@@ -127,12 +127,12 @@ export function createReallocateInstruction(
     record: PublicKey,
     authority: PublicKey,
     dataLength: number,
+    programId = RECORD_PROGRAM_ID,
 ) {
     const keys = [
         { pubkey: record, isSigner: false, isWritable: true },
         { pubkey: authority, isSigner: true, isWritable: false },
     ]
-    const programId = RECORD_PROGRAM_ID;
     const data = Buffer.from([RecordInstruction.Reallocate, ...toBufferLE(BigInt(dataLength), 8)]);
 
     return new TransactionInstruction({ keys, programId, data });

--- a/clients/js-legacy/src/instructions.ts
+++ b/clients/js-legacy/src/instructions.ts
@@ -1,5 +1,5 @@
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
-import { toBufferLE } from 'bigint-buffer';
+import { getU32Codec, getU64Codec } from '@solana/codecs-numbers';
 import { RECORD_PROGRAM_ID } from './constants';
 
 export enum RecordInstruction {
@@ -45,7 +45,7 @@ export function createInitializeInstruction(
 export function createWriteInstruction(
     record: PublicKey,
     authority: PublicKey,
-    offset: number,
+    offset: bigint,
     buffer: Uint8Array,
     programId = RECORD_PROGRAM_ID,
 ) {
@@ -53,11 +53,10 @@ export function createWriteInstruction(
         { pubkey: record, isSigner: false, isWritable: true },
         { pubkey: authority, isSigner: true, isWritable: false },
     ]
-    const bufferLength = BigInt(buffer.length);
     const data = Buffer.from([
         RecordInstruction.Write,
-        ...toBufferLE(BigInt(offset), 8),
-        ...toBufferLE(bufferLength, 4),
+        ...getU64Codec().encode(offset),
+        ...getU32Codec().encode(buffer.length),
         ...buffer
     ]);
 
@@ -126,14 +125,14 @@ export function createCloseAccountInstruction(
 export function createReallocateInstruction(
     record: PublicKey,
     authority: PublicKey,
-    dataLength: number,
+    dataLength: bigint,
     programId = RECORD_PROGRAM_ID,
 ) {
     const keys = [
         { pubkey: record, isSigner: false, isWritable: true },
         { pubkey: authority, isSigner: true, isWritable: false },
     ]
-    const data = Buffer.from([RecordInstruction.Reallocate, ...toBufferLE(BigInt(dataLength), 8)]);
+    const data = Buffer.from([RecordInstruction.Reallocate, ...getU64Codec().encode(dataLength)]);
 
     return new TransactionInstruction({ keys, programId, data });
 }

--- a/clients/js-legacy/src/instructions.ts
+++ b/clients/js-legacy/src/instructions.ts
@@ -1,0 +1,139 @@
+import { PublicKey, TransactionInstruction } from '@solana/web3.js';
+import { toBufferLE } from 'bigint-buffer';
+import { RECORD_PROGRAM_ID } from './constants';
+
+export enum RecordInstruction {
+    Initialize = 0,
+    Write = 1,
+    SetAuthority = 2,
+    CloseAccount = 3,
+    Reallocate = 4,
+}
+
+/**
+ * Construct an Initialize instruction
+ *
+ * @param record        The record account address
+ * @param authority     The record account authority
+ *
+ * @return Instruction to add to a transaction
+ */
+export function createInitializeInstruction(
+    record: PublicKey,
+    authority: PublicKey,
+) {
+    const keys = [
+        { pubkey: record, isSigner: false, isWritable: true },
+        { pubkey: authority, isSigner: false, isWritable: false },
+    ];
+    const programId = RECORD_PROGRAM_ID;
+    const data = Buffer.from([RecordInstruction.Initialize]);
+
+    return new TransactionInstruction({ keys, programId, data });
+}
+
+/**
+ * Construct a Write instruction
+ *
+ * @param record        The record account address
+ * @param authority     The record account authority
+ * @param offset        The offset for the record bytes
+ * @param buffer        The record bytes to be stored
+ *
+ * @return Instruction to add to a transaction
+ */
+export function createWriteInstruction(
+    record: PublicKey,
+    authority: PublicKey,
+    offset: number,
+    buffer: Uint8Array,
+) {
+    const keys = [
+        { pubkey: record, isSigner: false, isWritable: true },
+        { pubkey: authority, isSigner: true, isWritable: false },
+    ]
+    const programId = RECORD_PROGRAM_ID;
+    const bufferLength = BigInt(buffer.length);
+    const data = Buffer.from([
+        RecordInstruction.Write,
+        ...toBufferLE(BigInt(offset), 8),
+        ...toBufferLE(bufferLength, 4),
+        ...buffer
+    ]);
+
+    return new TransactionInstruction({ keys, programId, data });
+}
+
+/**
+ * Construct a SetAuthority instruction
+ *
+ * @param record             The record account address
+ * @param currentAuthority   The current record account authority
+ * @param newAuthority       The new record account authority
+ *
+ * @return Instruction to add to a transaction
+ */
+export function createSetAuthorityInstruction(
+    record: PublicKey,
+    currentAuthority: PublicKey,
+    newAuthority: PublicKey,
+) {
+    const keys = [
+        { pubkey: record, isSigner: false, isWritable: true },
+        { pubkey: currentAuthority, isSigner: true, isWritable: false },
+        { pubkey: newAuthority, isSigner: false, isWritable: false },
+    ]
+    const programId = RECORD_PROGRAM_ID;
+    const data = Buffer.from([RecordInstruction.SetAuthority]);
+
+    return new TransactionInstruction({ keys, programId, data });
+}
+
+/**
+ * Construct a CloseAccount instruction
+ *
+ * @param record            The record account address
+ * @param authority         The record account authority
+ * @param receiver          The receiving account for lamports
+ *
+ * @return Instruction to add to a transaction
+ */
+export function createCloseAccountInstruction(
+    record: PublicKey,
+    authority: PublicKey,
+    receiver: PublicKey,
+) {
+    const keys = [
+        { pubkey: record, isSigner: false, isWritable: true },
+        { pubkey: authority, isSigner: true, isWritable: false },
+        { pubkey: receiver, isSigner: false, isWritable: true },
+    ]
+    const programId = RECORD_PROGRAM_ID;
+    const data = Buffer.from([RecordInstruction.CloseAccount]);
+
+    return new TransactionInstruction({ keys, programId, data });
+}
+
+/**
+ * Construct a Reallocate instruction
+ *
+ * @param record            The record account address
+ * @param authority         The current record account authority
+ * @param dataLength        The new record size after reallocation
+ *
+ * @return Instruction to add to a transaction
+ */
+export function createReallocateInstruction(
+    record: PublicKey,
+    authority: PublicKey,
+    dataLength: number,
+) {
+    const keys = [
+        { pubkey: record, isSigner: false, isWritable: true },
+        { pubkey: authority, isSigner: true, isWritable: false },
+    ]
+    const programId = RECORD_PROGRAM_ID;
+    const data = Buffer.from([RecordInstruction.Reallocate, ...toBufferLE(BigInt(dataLength), 8)]);
+
+    return new TransactionInstruction({ keys, programId, data });
+}

--- a/clients/js-legacy/src/state.ts
+++ b/clients/js-legacy/src/state.ts
@@ -1,0 +1,29 @@
+import type { AccountInfo, Commitment, Connection } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
+import { RECORD_META_DATA_SIZE } from './constants';
+
+export interface RecordAccount {
+    version: number;
+    authority: PublicKey;
+    recordData: Buffer;
+}
+
+export async function getRecordAccount(
+    connection: Connection,
+    address: PublicKey,
+    commitment?: Commitment,
+) {
+    const info = await connection.getAccountInfo(address, commitment);
+    return parseRecordAccount(info);
+}
+
+export function parseRecordAccount(accountInfo: AccountInfo<Buffer> | null) {
+    if (accountInfo !== null && accountInfo.data.length >= RECORD_META_DATA_SIZE) {
+        const version = accountInfo.data[0];
+        const authority = new PublicKey(accountInfo.data.subarray(1, RECORD_META_DATA_SIZE));
+        const recordData = accountInfo.data.subarray(RECORD_META_DATA_SIZE)
+        return { version, authority, recordData };
+    } else {
+        return null;
+    }
+}

--- a/clients/js-legacy/test/basic.ts
+++ b/clients/js-legacy/test/basic.ts
@@ -4,7 +4,7 @@ import { Keypair } from '@solana/web3.js';
 import { newAccountWithLamports, getConnection } from './common';
 import {
     closeRecord,
-    initializeRecord,
+    createRecord,
     getRecordAccount,
     setAuthority,
     reallocateRecord,
@@ -32,7 +32,7 @@ describe('basic instructions', () => {
     });
 
     it('initialize', async () => {
-        await initializeRecord(
+        await createRecord(
             connection,
             payer,
             recordAccount,

--- a/clients/js-legacy/test/basic.ts
+++ b/clients/js-legacy/test/basic.ts
@@ -18,8 +18,8 @@ describe('basic instructions', () => {
     let recordAccount: Keypair;
     let recordAuthority: Keypair;
     let newRecordAuthority: Keypair;
-    let initialRecordSize: number;
-    let newRecordSize: number;
+    let initialRecordSize: bigint;
+    let newRecordSize: bigint;
     let recordData: Buffer;
     before(async () => {
         connection = await getConnection();
@@ -27,8 +27,8 @@ describe('basic instructions', () => {
         recordAccount = Keypair.generate();
         recordAuthority = Keypair.generate();
         newRecordAuthority = Keypair.generate();
-        initialRecordSize = 0;
-        newRecordSize = 5;
+        initialRecordSize = BigInt(0);
+        newRecordSize = BigInt(5);
         recordData = Buffer.from([0, 1, 2, 3, 4]);
     });
 
@@ -73,7 +73,7 @@ describe('basic instructions', () => {
             payer,
             recordAccount.publicKey,
             recordAuthority,
-            0,
+            BigInt(0),
             recordData
         );
 

--- a/clients/js-legacy/test/basic.ts
+++ b/clients/js-legacy/test/basic.ts
@@ -100,7 +100,7 @@ describe('basic instructions', () => {
 
     it('close', async () => {
         const destination = Keypair.generate();
-        const recordAccountSize = RECORD_META_DATA_SIZE + 5;
+        const recordAccountSize = BigInt(RECORD_META_DATA_SIZE) + newRecordSize;
         const recordAccountLamports = await connection.getMinimumBalanceForRentExemption(Number(recordAccountSize));
 
         await closeRecord(

--- a/clients/js-legacy/test/basic.ts
+++ b/clients/js-legacy/test/basic.ts
@@ -1,0 +1,110 @@
+import { expect } from 'chai';
+import type { Connection, Signer } from '@solana/web3.js';
+import { Keypair } from '@solana/web3.js';
+import { newAccountWithLamports, getConnection } from './common';
+import {
+    closeRecord,
+    initializeRecord,
+    getRecordAccount,
+    setAuthority,
+    reallocateRecord,
+    writeRecord,
+} from '../src';
+
+describe('basic instructions', () => {
+    let connection: Connection;
+    let payer: Signer;
+    let recordAccount: Keypair;
+    let recordAuthority: Keypair;
+    let newRecordAuthority: Keypair;
+    let initialRecordSize: number;
+    let newRecordSize: number;
+    let recordData: Buffer;
+    before(async () => {
+        connection = await getConnection();
+        payer = await newAccountWithLamports(connection, 1000000000);
+        recordAccount = Keypair.generate();
+        recordAuthority = Keypair.generate();
+        newRecordAuthority = Keypair.generate();
+        initialRecordSize = 0;
+        newRecordSize = 5;
+        recordData = Buffer.from([0, 1, 2, 3, 4]);
+    });
+
+    it('initialize', async () => {
+        await initializeRecord(
+            connection,
+            payer,
+            recordAccount,
+            recordAuthority.publicKey,
+            initialRecordSize,
+        );
+
+        const recordAccountData = await getRecordAccount(connection, recordAccount.publicKey);
+        expect(recordAccountData).to.not.equal(null);
+        if (recordAccountData !== null) {
+            expect(recordAccountData.version).to.eql(1);
+            expect(recordAccountData.authority).to.eql(recordAuthority.publicKey);
+            expect(recordAccountData.recordData).to.eql(Buffer.from([]));
+        }
+    });
+
+    it('reallocate', async () => {
+        await reallocateRecord(
+            connection,
+            payer,
+            recordAccount.publicKey,
+            recordAuthority,
+            newRecordSize,
+            true,
+        );
+
+        const recordAccountData = await getRecordAccount(connection, recordAccount.publicKey);
+        expect(recordAccountData).to.not.equal(null);
+        if (recordAccountData !== null) {
+            expect(recordAccountData.recordData).to.eql(Buffer.from([0, 0, 0, 0, 0]));
+        }
+    })
+
+    it('write', async () => {
+        await writeRecord(
+            connection,
+            payer,
+            recordAccount.publicKey,
+            recordAuthority,
+            0,
+            recordData
+        );
+
+        const recordAccountData = await getRecordAccount(connection, recordAccount.publicKey);
+        if (recordAccountData !== null) {
+            expect(recordAccountData.recordData).to.eql(Buffer.from([0, 1, 2, 3, 4]));
+        }
+    })
+
+    it('set authority', async () => {
+        await setAuthority(
+            connection,
+            payer,
+            recordAccount.publicKey,
+            recordAuthority,
+            newRecordAuthority.publicKey,
+        );
+
+        const recordAccountData = await getRecordAccount(connection, recordAccount.publicKey);
+        if (recordAccountData !== null) {
+            expect(recordAccountData.authority).to.eql(newRecordAuthority.publicKey);
+        }
+    })
+
+    it('close', async () => {
+        const receiver = Keypair.generate();
+        await closeRecord(
+            connection,
+            payer,
+            recordAccount.publicKey,
+            newRecordAuthority,
+            receiver.publicKey,
+        )
+    });
+})

--- a/clients/js-legacy/test/common.ts
+++ b/clients/js-legacy/test/common.ts
@@ -1,0 +1,20 @@
+import type { Signer } from '@solana/web3.js';
+import { Keypair, Connection } from '@solana/web3.js';
+
+export async function newAccountWithLamports(connection: Connection, lamports = 1000000): Promise<Signer> {
+    const account = Keypair.generate();
+    const signature = await connection.requestAirdrop(account.publicKey, lamports);
+    const latestBlockHash = await connection.getLatestBlockhash();
+    await connection.confirmTransaction({
+        blockhash: latestBlockHash.blockhash,
+        lastValidBlockHeight: latestBlockHash.lastValidBlockHeight,
+        signature,
+    });
+    return account;
+}
+
+export async function getConnection(): Promise<Connection> {
+    const url = 'http://127.0.0.1:8899';
+    const connection = new Connection(url, 'confirmed');
+    return connection;
+}

--- a/clients/js-legacy/test/longRecord.ts
+++ b/clients/js-legacy/test/longRecord.ts
@@ -3,7 +3,7 @@ import type { Connection, Signer } from '@solana/web3.js';
 import { Keypair } from '@solana/web3.js';
 import { newAccountWithLamports, getConnection } from './common';
 import {
-    initializeWriteRecord,
+    createInitializeWriteRecord,
     getRecordAccount,
 } from '../src';
 
@@ -22,7 +22,7 @@ describe('long record data', () => {
     });
 
     it('initialize and write', async () => {
-        await initializeWriteRecord(
+        await createInitializeWriteRecord(
             connection,
             payer,
             recordAccount,

--- a/clients/js-legacy/test/longRecord.ts
+++ b/clients/js-legacy/test/longRecord.ts
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import type { Connection, Signer } from '@solana/web3.js';
+import { Keypair } from '@solana/web3.js';
+import { newAccountWithLamports, getConnection } from './common';
+import {
+    initializeWriteRecord,
+    getRecordAccount,
+} from '../src';
+
+describe('long record data', () => {
+    let connection: Connection;
+    let payer: Signer;
+    let recordAccount: Keypair;
+    let recordAuthority: Keypair;
+    let recordData: Buffer;
+    before(async () => {
+        connection = await getConnection();
+        payer = await newAccountWithLamports(connection, 1000000000);
+        recordAccount = Keypair.generate();
+        recordAuthority = Keypair.generate();
+        recordData = Buffer.from(Array(5000).fill(127));
+    });
+
+    it('initialize and write', async () => {
+        await initializeWriteRecord(
+            connection,
+            payer,
+            recordAccount,
+            recordAuthority,
+            0,
+            recordData,
+        );
+
+        const recordAccountData = await getRecordAccount(connection, recordAccount.publicKey);
+        expect(recordAccountData).to.not.equal(null);
+        if (recordAccountData !== null) {
+            expect(recordAccountData.version).to.eql(1);
+            expect(recordAccountData.authority).to.eql(recordAuthority.publicKey);
+            expect(recordAccountData.recordData).to.eql(recordData);
+        }
+    });
+})

--- a/clients/js-legacy/test/longRecord.ts
+++ b/clients/js-legacy/test/longRecord.ts
@@ -27,7 +27,7 @@ describe('long record data', () => {
             payer,
             recordAccount,
             recordAuthority,
-            0,
+            BigInt(0),
             recordData,
         );
 

--- a/clients/js-legacy/tsconfig.json
+++ b/clients/js-legacy/tsconfig.json
@@ -1,0 +1,28 @@
+{
+    "compilerOptions": {
+        "composite": false,
+        "declaration": true,
+        "declarationMap": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "inlineSources": false,
+        "isolatedModules": true,
+        "module": "ESNext",
+        "moduleResolution": "node",
+        "noFallthroughCasesInSwitch": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "outDir": "./dist",
+        "preserveWatchOutput": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "target": "ESNext"
+    },
+    "exclude": [
+        "node_modules"
+    ],
+    "include": [
+        "src",
+        "test"
+    ]
+}


### PR DESCRIPTION
#### Problem
There is currently no js clients for interacting with the record program.

#### Summary of Changes
I took a first stab at adding the js(-legacy) client.

I did not touch the CI yet to keep the changes as small as possible. For the test script, I added the following script for now.,
```
"test": "start-server-and-test 'solana-test-validator --bpf-program recr1L3PCGKLbckBqMNcJhuuyU1zgo8nBhfLVsJNwr5 ../../target/deploy/spl_record.so --reset --quiet' http://127.0.0.1:8899/health 'mocha test'"
```
So to run the test, run `pnpm test`. When the CI is added in a follow-up PR, this script can be updated to match that of `solana-program/token-2022` clients.

For the added client itself:
- I used the `bigint-buffer` package to convert numbers into little endian byte arrays. If there is a more idiomatic way to do this please let me know.
- I added `RECORD_CHUNK_SIZE_PRE_INITIALIZE = 696` and `RECORD_CHUNK_SIZE_POST_INITIALIZE = 919` constants that specify the maximum chunk data size that can be included in an instruction. It would be nice to be able to compute this dynamically like in the token-2022 rust client, but I made these numbers constants for now.
- I used `number` type instead of `bigint` for variables like `offset` and `recordSize`. The program technically supports `u64` offset and size values, but keeping these as numbers seemed to simplify the interface a bit. Please let me know if we prefer to use `bigint` instead.

Other than that, I think it should be pretty straightforward unless there are things that I am overlooking.