### PR TITLE
[program] Add security-txt to program and add `SECURITY.md`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5630,6 +5630,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-security-txt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "468aa43b7edb1f9b7b7b686d5c3aeb6630dc1708e86e31343499dd5c4d775183"
+
+[[package]]
 name = "solana-seed-derivable"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6522,6 +6528,7 @@ dependencies = [
  "solana-pubkey",
  "solana-rent",
  "solana-sdk",
+ "solana-security-txt",
  "thiserror 2.0.12",
 ]
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,76 @@
+# Security Policy
+
+1. [Reporting security problems](#reporting)
+1. [Security Bug Bounties](#bounty)
+1. [Scope](#scope)
+1. [Incident Response Process](#process)
+
+<a name="reporting"></a>
+
+## Reporting security problems in the Solana Program Library
+
+**DO NOT CREATE A GITHUB ISSUE** to report a security problem.
+
+Instead please use this [Report a Vulnerability](https://github.com/solana-labs/solana-program-library/security/advisories/new) link.
+Provide a helpful title and detailed description of the problem.
+
+If you haven't done so already, please **enable two-factor auth** in your GitHub account.
+
+Expect a response as fast as possible in the advisory, typically within 72 hours.
+
+--
+
+If you do not receive a response in the advisory, send an email to
+security@solana.com with the full URL of the advisory you have created. DO NOT
+include attachments or provide detail sufficient for exploitation regarding the
+security issue in this email. **Only provide such details in the advisory**.
+
+If you do not receive a response from security@solana.com please followup with
+the team directly. You can do this in the `#core-technology` channel of the
+[Solana Tech discord server](https://solana.com/discord), by pinging the admins
+in the channel and referencing the fact that you submitted a security problem.
+
+<a name="bounty"></a>
+
+## Security Bug Bounties
+
+The Solana Foundation offer bounties for critical Solana security issues. Please
+see the [Solana Security Bug
+Bounties](https://github.com/solana-labs/solana/security/policy#security-bug-bounties)
+for details on classes of bugs and payment amounts.
+
+<a name="scope"></a>
+
+## Scope
+
+Only a subset of programs within the Solana Program Library repo are deployed to
+the Solana Mainnet Beta. Currently, this includes:
+
+- [associated-token-account](https://github.com/solana-labs/solana-program-library/tree/master/associated-token-account/program)
+- [feature-proposal](https://github.com/solana-labs/solana-program-library/tree/master/feature-proposal/program)
+- [governance](https://github.com/solana-labs/solana-program-library/tree/master/governance/program)
+- [memo](https://github.com/solana-labs/solana-program-library/tree/master/memo/program)
+- [name-service](https://github.com/solana-labs/solana-program-library/tree/master/name-service/program)
+- [stake-pool](https://github.com/solana-labs/solana-program-library/tree/master/stake-pool/program)
+- [token](https://github.com/solana-labs/solana-program-library/tree/master/token/program)
+- [token-2022](https://github.com/solana-labs/solana-program-library/tree/master/token/program-2022)
+
+If you discover a critical security issue in an out-of-scope program, your finding
+may still be valuable.
+
+Many programs, including
+[token-swap](https://github.com/solana-labs/solana-program-library/tree/master/token-swap/program)
+and [token-lending](https://github.com/solana-labs/solana-program-library/tree/master/token-lending/program),
+have been forked and deployed by prominent ecosystem projects, many of which
+have their own bug bounty programs.
+
+While we cannot guarantee a bounty from another entity, we can help determine who
+may be affected and put you in touch with the corresponding teams.
+
+<a name="process"></a>
+
+## Incident Response Process
+
+In case an incident is discovered or reported, the
+[Solana Security Incident Response Process](https://github.com/solana-labs/solana/security/policy#incident-response-process)
+will be followed to contain, respond and remediate.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,17 +1,10 @@
 # Security Policy
 
-1. [Reporting security problems](#reporting)
-1. [Security Bug Bounties](#bounty)
-1. [Scope](#scope)
-1. [Incident Response Process](#process)
-
-<a name="reporting"></a>
-
-## Reporting security problems in the Solana Program Library
+## Reporting security problems
 
 **DO NOT CREATE A GITHUB ISSUE** to report a security problem.
 
-Instead please use this [Report a Vulnerability](https://github.com/solana-labs/solana-program-library/security/advisories/new) link.
+Instead please use this [Report a Vulnerability](https://github.com/solana-program/record/security/advisories/new) link.
 Provide a helpful title and detailed description of the problem.
 
 If you haven't done so already, please **enable two-factor auth** in your GitHub account.
@@ -21,56 +14,11 @@ Expect a response as fast as possible in the advisory, typically within 72 hours
 --
 
 If you do not receive a response in the advisory, send an email to
-security@solana.com with the full URL of the advisory you have created. DO NOT
+<security@solana.com> with the full URL of the advisory you have created. DO NOT
 include attachments or provide detail sufficient for exploitation regarding the
 security issue in this email. **Only provide such details in the advisory**.
 
-If you do not receive a response from security@solana.com please followup with
-the team directly. You can do this in the `#core-technology` channel of the
+If you do not receive a response from <security@solana.com> please followup with
+the team directly. You can do this in one of the `#Dev Tooling` channels of the
 [Solana Tech discord server](https://solana.com/discord), by pinging the admins
 in the channel and referencing the fact that you submitted a security problem.
-
-<a name="bounty"></a>
-
-## Security Bug Bounties
-
-The Solana Foundation offer bounties for critical Solana security issues. Please
-see the [Solana Security Bug
-Bounties](https://github.com/solana-labs/solana/security/policy#security-bug-bounties)
-for details on classes of bugs and payment amounts.
-
-<a name="scope"></a>
-
-## Scope
-
-Only a subset of programs within the Solana Program Library repo are deployed to
-the Solana Mainnet Beta. Currently, this includes:
-
-- [associated-token-account](https://github.com/solana-labs/solana-program-library/tree/master/associated-token-account/program)
-- [feature-proposal](https://github.com/solana-labs/solana-program-library/tree/master/feature-proposal/program)
-- [governance](https://github.com/solana-labs/solana-program-library/tree/master/governance/program)
-- [memo](https://github.com/solana-labs/solana-program-library/tree/master/memo/program)
-- [name-service](https://github.com/solana-labs/solana-program-library/tree/master/name-service/program)
-- [stake-pool](https://github.com/solana-labs/solana-program-library/tree/master/stake-pool/program)
-- [token](https://github.com/solana-labs/solana-program-library/tree/master/token/program)
-- [token-2022](https://github.com/solana-labs/solana-program-library/tree/master/token/program-2022)
-
-If you discover a critical security issue in an out-of-scope program, your finding
-may still be valuable.
-
-Many programs, including
-[token-swap](https://github.com/solana-labs/solana-program-library/tree/master/token-swap/program)
-and [token-lending](https://github.com/solana-labs/solana-program-library/tree/master/token-lending/program),
-have been forked and deployed by prominent ecosystem projects, many of which
-have their own bug bounty programs.
-
-While we cannot guarantee a bounty from another entity, we can help determine who
-may be affected and put you in touch with the corresponding teams.
-
-<a name="process"></a>
-
-## Incident Response Process
-
-In case an incident is discovered or reported, the
-[Solana Security Incident Response Process](https://github.com/solana-labs/solana/security/policy#incident-response-process)
-will be followed to contain, respond and remediate.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,11 +14,11 @@ Expect a response as fast as possible in the advisory, typically within 72 hours
 --
 
 If you do not receive a response in the advisory, send an email to
-<security@solana.com> with the full URL of the advisory you have created. DO NOT
+<security@anza.xyz> with the full URL of the advisory you have created. DO NOT
 include attachments or provide detail sufficient for exploitation regarding the
 security issue in this email. **Only provide such details in the advisory**.
 
-If you do not receive a response from <security@solana.com> please followup with
+If you do not receive a response from <security@anza.xyz> please followup with
 the team directly. You can do this in one of the `#Dev Tooling` channels of the
 [Solana Tech discord server](https://solana.com/discord), by pinging the admins
 in the channel and referencing the fact that you submitted a security problem.

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -24,6 +24,7 @@ solana-program-error = "2.2.1"
 solana-program-pack = "2.2.1"
 solana-pubkey = { version = "2.2.1", features = ["bytemuck"] }
 solana-rent = "2.2.1"
+solana-security-txt = "1.1.1"
 thiserror = "2.0.12"
 
 [dev-dependencies]

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -25,5 +25,5 @@ security_txt! {
 
     // Optional Fields
     preferred_languages: "en",
-    source_code: "https://github.com/solana-program/record/tree/master/program",
+    source_code: "https://github.com/solana-program/record/tree/master/program"
 }

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -4,6 +4,7 @@
 
 use {
     solana_account_info::AccountInfo, solana_program_error::ProgramResult, solana_pubkey::Pubkey,
+    solana_security_txt::security_txt,
 };
 
 solana_program_entrypoint::entrypoint!(process_instruction);

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -14,3 +14,15 @@ fn process_instruction(
 ) -> ProgramResult {
     crate::processor::process_instruction(program_id, accounts, instruction_data)
 }
+
+security_txt! {
+    // Required fields
+    name: "SPL Record",
+    project_url: "https://solana-program.com/record",
+    contacts: "link:https://github.com/solana-program/record/security/advisories/new,mailto:security@anza.xyz,discord:https://solana.com/discord",
+    policy: "https://github.com/solana-program/record/blob/master/SECURITY.md",
+
+    // Optional Fields
+    preferred_languages: "en",
+    source_code: "https://github.com/solana-program/record/tree/master/program",
+}


### PR DESCRIPTION
#### Problem

There is no security-txt in the record program yet.

#### Summary of Changes

Added security-txt and also added `SECURITY.md`.

For `SECURITY.md`, I first copied it verbatim from the old solana-program-library repo. I then updated the file:
- I removed the part on bug bounties. The solana-program-library `SECURITY.md` pointed to the bug bounty section of the old solana `SECURITY.md`. In both (old) solana and agave `SECURITY.md`, it is written that spl programs are excluded from the bug bounties, so I thought it made sense to remove this section. If there is a boundy, then please let me know and I can add it back in.
- The scope section is not relevant any more so I removed it.
- The incident response process linked to the old solana `SECURITY.md` incident response section. I considered tailoring that section to here, but it seemed pretty specific to validators. I ended up removing it, but I can add more detail if suggested.