### PR TITLE
deps: Bump to SDK v4 / address v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "ahash",
  "solana-epoch-schedule",
  "solana-hash 3.1.0",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-sha256-hasher",
  "solana-svm-feature-set",
 ]
@@ -40,7 +40,7 @@ dependencies = [
  "solana-poseidon",
  "solana-program-entrypoint",
  "solana-program-runtime",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-secp256k1-recover",
@@ -706,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "five8_const"
-version = "0.1.3"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b4f62f0f8ca357f93ae90c8c2dd1041a1f665fde2f889ea9b1787903829015"
+checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
  "five8_core",
 ]
@@ -978,7 +978,7 @@ dependencies = [
  "solana-precompile-error",
  "solana-program-error",
  "solana-program-runtime",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-rent",
  "solana-sdk-ids",
  "solana-slot-hashes",
@@ -998,7 +998,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "682ad3a990ae8f336ee10f402da2e900a37cff38730e29aa8cda2d82e1b2e9f1"
 dependencies = [
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "thiserror 1.0.69",
 ]
 
@@ -1011,7 +1011,7 @@ dependencies = [
  "mollusk-svm-error",
  "solana-account",
  "solana-instruction",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-transaction-context",
 ]
 
@@ -1024,7 +1024,7 @@ dependencies = [
  "solana-account",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-rent",
 ]
 
@@ -1526,37 +1526,47 @@ dependencies = [
  "solana-account-info",
  "solana-clock",
  "solana-instruction-error",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-sdk-ids",
  "solana-sysvar",
 ]
 
 [[package]]
 name = "solana-account-info"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82f4691b69b172c687d218dd2f1f23fc7ea5e9aa79df9ac26dab3d8dd829ce48"
+checksum = "fc3397241392f5756925029acaa8515dc70fcbe3d8059d4885d7d6533baf64fd"
 dependencies = [
+ "solana-address 2.0.0",
  "solana-program-error",
  "solana-program-memory",
- "solana-pubkey",
 ]
 
 [[package]]
 name = "solana-address"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7a457086457ea9db9a5199d719dc8734dc2d0342fad0d8f77633c31eb62f19"
+checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
 dependencies = [
+ "solana-address 2.0.0",
+]
+
+[[package]]
+name = "solana-address"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e37320fd2945c5d654b2c6210624a52d66c3f1f73b653ed211ab91a703b35bdd"
+dependencies = [
+ "borsh",
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek",
- "five8 0.2.1",
+ "five8 1.0.0",
  "five8_const",
  "serde",
  "serde_derive",
  "solana-atomic-u64",
- "solana-define-syscall",
+ "solana-define-syscall 4.0.1",
  "solana-program-error",
  "solana-sanitize",
  "solana-sha256-hasher",
@@ -1579,7 +1589,7 @@ checksum = "30c80fb6d791b3925d5ec4bf23a7c169ef5090c013059ec3ed7d0b2c04efa085"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0",
 ]
 
 [[package]]
@@ -1600,7 +1610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffa2e3bdac3339c6d0423275e45dafc5ac25f4d43bf344d026a3cc9a85e244a6"
 dependencies = [
  "blake3",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0",
  "solana-hash 3.1.0",
 ]
 
@@ -1615,7 +1625,7 @@ dependencies = [
  "ark-ff",
  "ark-serialize",
  "bytemuck",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0",
  "thiserror 2.0.17",
 ]
 
@@ -1637,14 +1647,14 @@ dependencies = [
  "solana-packet",
  "solana-program-entrypoint",
  "solana-program-runtime",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-sbpf",
  "solana-sdk-ids",
  "solana-svm-feature-set",
  "solana-svm-log-collector",
  "solana-svm-measure",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-transaction-context",
 ]
 
@@ -1678,10 +1688,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16238feb63d1cbdf915fb287f29ef7a7ebf81469bd6214f8b72a53866b593f8f"
 dependencies = [
  "solana-account-info",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-stable-layout",
 ]
 
@@ -1694,7 +1704,7 @@ dependencies = [
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0",
  "subtle",
  "thiserror 2.0.17",
 ]
@@ -1704,6 +1714,12 @@ name = "solana-define-syscall"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9697086a4e102d28a156b8d6b521730335d6951bd39a5e766512bbe09007cee"
+
+[[package]]
+name = "solana-define-syscall"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
 
 [[package]]
 name = "solana-epoch-rewards"
@@ -1776,16 +1792,17 @@ dependencies = [
 
 [[package]]
 name = "solana-instruction"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df4e8fcba01d7efa647ed20a081c234475df5e11a93acb4393cc2c9a7b99bab"
+checksum = "ee1b699a2c1518028a9982e255e0eca10c44d90006542d9d7f9f40dbce3f7c78"
 dependencies = [
  "bincode",
+ "borsh",
  "serde",
  "serde_derive",
- "solana-define-syscall",
+ "solana-define-syscall 4.0.1",
  "solana-instruction-error",
- "solana-pubkey",
+ "solana-pubkey 4.0.0",
 ]
 
 [[package]]
@@ -1811,7 +1828,7 @@ dependencies = [
  "solana-instruction",
  "solana-instruction-error",
  "solana-program-error",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-sanitize",
  "solana-sdk-ids",
  "solana-serialize-utils",
@@ -1825,7 +1842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57eebd3012946913c8c1b8b43cdf8a6249edb09c0b6be3604ae910332a3acd97"
 dependencies = [
  "sha3",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0",
  "solana-hash 3.1.0",
 ]
 
@@ -1852,7 +1869,7 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "solana-instruction",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-sdk-ids",
 ]
 
@@ -1866,9 +1883,9 @@ dependencies = [
  "serde_bytes",
  "serde_derive",
  "solana-instruction",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-sdk-ids",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
 ]
 
 [[package]]
@@ -1891,7 +1908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85666605c9fd727f865ed381665db0a8fc29f984a030ecc1e40f43bfb2541623"
 dependencies = [
  "lazy_static",
- "solana-address",
+ "solana-address 1.1.0",
  "solana-hash 3.1.0",
  "solana-instruction",
  "solana-sanitize",
@@ -1905,7 +1922,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "264275c556ea7e22b9d3f87d56305546a38d4eee8ec884f3b126236cb7dcbbb4"
 dependencies = [
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0",
 ]
 
 [[package]]
@@ -1918,7 +1935,7 @@ dependencies = [
  "serde_derive",
  "solana-fee-calculator",
  "solana-hash 3.1.0",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-sha256-hasher",
 ]
 
@@ -1951,7 +1968,7 @@ checksum = "794ff76c70d6f4c5d9c86c626069225c0066043405c0c9d6b96f00c8525dade5"
 dependencies = [
  "ark-bn254",
  "light-poseidon",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0",
  "thiserror 2.0.17",
 ]
 
@@ -1971,10 +1988,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6557cf5b5e91745d1667447438a1baa7823c6086e4ece67f8e6ebfa7a8f72660"
 dependencies = [
  "solana-account-info",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0",
  "solana-msg",
  "solana-program-error",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
@@ -1989,7 +2006,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10e5660c60749c7bfb30b447542529758e4dbcecd31b1e8af1fdc92e2bdde90a"
 dependencies = [
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0",
 ]
 
 [[package]]
@@ -2023,7 +2040,7 @@ dependencies = [
  "solana-instruction",
  "solana-last-restart-slot",
  "solana-program-entrypoint",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
@@ -2036,7 +2053,7 @@ dependencies = [
  "solana-svm-timings",
  "solana-svm-transaction",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-sysvar-id",
  "solana-transaction-context",
@@ -2048,7 +2065,16 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8909d399deb0851aa524420beeb5646b115fd253ef446e35fe4504c904da3941"
 dependencies = [
- "solana-address",
+ "solana-address 1.1.0",
+]
+
+[[package]]
+name = "solana-pubkey"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6f7104d456b58e1418c21a8581e89810278d1190f70f27ece7fc0b2c9282a57"
+dependencies = [
+ "solana-address 2.0.0",
 ]
 
 [[package]]
@@ -2093,7 +2119,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1b6d6aaf60669c592838d382266b173881c65fb1cdec83b37cb8ce7cb89f9ad"
 dependencies = [
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
@@ -2115,7 +2141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "394a4470477d66296af5217970a905b1c5569032a7732c367fb69e5666c8607e"
 dependencies = [
  "k256",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0",
  "thiserror 2.0.17",
 ]
 
@@ -2132,7 +2158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e41dd8feea239516c623a02f0a81c2367f4b604d7965237fed0751aeec33ed"
 dependencies = [
  "solana-instruction-error",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-sanitize",
 ]
 
@@ -2143,7 +2169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9b912ba6f71cb202c0c3773ec77bf898fa9fe0c78691a2d6859b3b5b8954719"
 dependencies = [
  "sha2 0.10.8",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0",
  "solana-hash 3.1.0",
 ]
 
@@ -2190,7 +2216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1da74507795b6e8fb60b7c7306c0c36e2c315805d16eaaf479452661234685ac"
 dependencies = [
  "solana-instruction",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
@@ -2206,8 +2232,8 @@ dependencies = [
  "solana-cpi",
  "solana-instruction",
  "solana-program-error",
- "solana-pubkey",
- "solana-system-interface",
+ "solana-pubkey 3.0.0",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-sysvar-id",
 ]
@@ -2221,7 +2247,7 @@ dependencies = [
  "solana-account",
  "solana-clock",
  "solana-precompile-error",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
@@ -2253,7 +2279,7 @@ checksum = "62606f820fe99b72ee8e26b8e20eed3c2ccc2f6e3146f537c4cb22a442c69170"
 dependencies = [
  "eager",
  "enum-iterator",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
 ]
 
 [[package]]
@@ -2264,7 +2290,7 @@ checksum = "336583f8418964f7050b98996e13151857995604fe057c0d8f2f3512a16d3a8b"
 dependencies = [
  "solana-hash 3.1.0",
  "solana-message",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-sdk-ids",
  "solana-signature",
  "solana-transaction",
@@ -2291,7 +2317,22 @@ dependencies = [
  "solana-instruction",
  "solana-msg",
  "solana-program-error",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
+]
+
+[[package]]
+name = "solana-system-interface"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14591d6508042ebefb110305d3ba761615927146a26917ade45dc332d8e1ecde"
+dependencies = [
+ "num-traits",
+ "serde",
+ "serde_derive",
+ "solana-address 2.0.0",
+ "solana-instruction",
+ "solana-msg",
+ "solana-program-error",
 ]
 
 [[package]]
@@ -2312,11 +2353,11 @@ dependencies = [
  "solana-nonce-account",
  "solana-packet",
  "solana-program-runtime",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-sdk-ids",
  "solana-svm-log-collector",
  "solana-svm-type-overrides",
- "solana-system-interface",
+ "solana-system-interface 2.0.0",
  "solana-sysvar",
  "solana-transaction-context",
 ]
@@ -2334,7 +2375,7 @@ dependencies = [
  "serde_derive",
  "solana-account-info",
  "solana-clock",
- "solana-define-syscall",
+ "solana-define-syscall 3.0.0",
  "solana-epoch-rewards",
  "solana-epoch-schedule",
  "solana-fee-calculator",
@@ -2344,7 +2385,7 @@ dependencies = [
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-program-memory",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-rent",
  "solana-sdk-ids",
  "solana-sdk-macro",
@@ -2359,7 +2400,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5051bc1a16d5d96a96bc33b5b2ec707495c48fe978097bdaba68d3c47987eb32"
 dependencies = [
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-sdk-ids",
 ]
 
@@ -2369,7 +2410,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64928e6af3058dcddd6da6680cbe08324b4e071ad73115738235bbaa9e9f72a5"
 dependencies = [
- "solana-address",
+ "solana-address 1.1.0",
  "solana-hash 3.1.0",
  "solana-instruction",
  "solana-instruction-error",
@@ -2393,7 +2434,7 @@ dependencies = [
  "solana-account",
  "solana-instruction",
  "solana-instructions-sysvar",
- "solana-pubkey",
+ "solana-pubkey 3.0.0",
  "solana-rent",
  "solana-sbpf",
  "solana-sdk-ids",
@@ -2429,15 +2470,15 @@ dependencies = [
  "num-traits",
  "solana-account",
  "solana-account-info",
+ "solana-address 2.0.0",
  "solana-instruction",
  "solana-msg",
  "solana-program-entrypoint",
  "solana-program-error",
  "solana-program-pack",
- "solana-pubkey",
  "solana-rent",
  "solana-security-txt",
- "solana-system-interface",
+ "solana-system-interface 3.0.0",
  "thiserror 2.0.17",
 ]
 

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -14,21 +14,22 @@ no-entrypoint = []
 bytemuck = { version = "1.23.1", features = ["derive"] }
 num-derive = "0.4"
 num-traits = "0.2"
-solana-account-info = "3.0.0"
-solana-instruction = { version = "3.0.0", features = ["std"] }
+solana-account-info = "3.1.0"
+solana-address = { version = "2.0.0", features = ["bytemuck", "decode"] }
+solana-instruction = { version = "3.1.0", features = ["std"] }
 solana-msg = "3.0.0"
-solana-program-entrypoint = "3.0.0"
+solana-program-entrypoint = "3.1.0"
 solana-program-error = "3.0.0"
 solana-program-pack = "3.0.0"
-solana-pubkey = { version = "3.0.0", features = ["bytemuck"] }
 solana-rent = "3.0.0"
 solana-security-txt = "1.1.1"
 thiserror = "2.0.12"
 
 [dev-dependencies]
 mollusk-svm = "0.7.0"
-solana-account = "3.0.0"
-solana-system-interface = "2"
+solana-account = "3.1.0"
+solana-address = { version = "2.0.0", features = ["atomic"] }
+solana-system-interface = { version = "3", features = ["bincode"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -3,13 +3,13 @@
 #![cfg(all(target_os = "solana", not(feature = "no-entrypoint")))]
 
 use {
-    solana_account_info::AccountInfo, solana_program_error::ProgramResult, solana_pubkey::Pubkey,
+    solana_account_info::AccountInfo, solana_address::Address, solana_program_error::ProgramResult,
     solana_security_txt::security_txt,
 };
 
 solana_program_entrypoint::entrypoint!(process_instruction);
 fn process_instruction(
-    program_id: &Pubkey,
+    program_id: &Address,
     accounts: &[AccountInfo],
     instruction_data: &[u8],
 ) -> ProgramResult {

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -2,9 +2,9 @@
 
 use {
     crate::id,
+    solana_address::Address,
     solana_instruction::{AccountMeta, Instruction},
     solana_program_error::ProgramError,
-    solana_pubkey::Pubkey,
     std::mem::size_of,
 };
 
@@ -134,7 +134,7 @@ impl<'a> RecordInstruction<'a> {
 }
 
 /// Create a `RecordInstruction::Initialize` instruction
-pub fn initialize(record_account: &Pubkey, authority: &Pubkey) -> Instruction {
+pub fn initialize(record_account: &Address, authority: &Address) -> Instruction {
     Instruction {
         program_id: id(),
         accounts: vec![
@@ -146,7 +146,7 @@ pub fn initialize(record_account: &Pubkey, authority: &Pubkey) -> Instruction {
 }
 
 /// Create a `RecordInstruction::Write` instruction
-pub fn write(record_account: &Pubkey, signer: &Pubkey, offset: u64, data: &[u8]) -> Instruction {
+pub fn write(record_account: &Address, signer: &Address, offset: u64, data: &[u8]) -> Instruction {
     Instruction {
         program_id: id(),
         accounts: vec![
@@ -159,9 +159,9 @@ pub fn write(record_account: &Pubkey, signer: &Pubkey, offset: u64, data: &[u8])
 
 /// Create a `RecordInstruction::SetAuthority` instruction
 pub fn set_authority(
-    record_account: &Pubkey,
-    signer: &Pubkey,
-    new_authority: &Pubkey,
+    record_account: &Address,
+    signer: &Address,
+    new_authority: &Address,
 ) -> Instruction {
     Instruction {
         program_id: id(),
@@ -175,7 +175,11 @@ pub fn set_authority(
 }
 
 /// Create a `RecordInstruction::CloseAccount` instruction
-pub fn close_account(record_account: &Pubkey, signer: &Pubkey, receiver: &Pubkey) -> Instruction {
+pub fn close_account(
+    record_account: &Address,
+    signer: &Address,
+    receiver: &Address,
+) -> Instruction {
     Instruction {
         program_id: id(),
         accounts: vec![
@@ -188,7 +192,7 @@ pub fn close_account(record_account: &Pubkey, signer: &Pubkey, receiver: &Pubkey
 }
 
 /// Create a `RecordInstruction::Reallocate` instruction
-pub fn reallocate(record_account: &Pubkey, signer: &Pubkey, data_length: u64) -> Instruction {
+pub fn reallocate(record_account: &Address, signer: &Address, data_length: u64) -> Instruction {
     Instruction {
         program_id: id(),
         accounts: vec![

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -10,8 +10,8 @@ pub mod state;
 // Export current SDK types for downstream users building with a different SDK
 // version
 pub use {
-    solana_account_info, solana_instruction, solana_msg, solana_program_entrypoint,
-    solana_program_error, solana_program_pack, solana_pubkey,
+    solana_account_info, solana_address, solana_instruction, solana_msg, solana_program_entrypoint,
+    solana_program_error, solana_program_pack,
 };
 
-solana_pubkey::declare_id!("recr1L3PCGKLbckBqMNcJhuuyU1zgo8nBhfLVsJNwr5");
+solana_address::declare_id!("recr1L3PCGKLbckBqMNcJhuuyU1zgo8nBhfLVsJNwr5");

--- a/program/src/processor.rs
+++ b/program/src/processor.rs
@@ -3,13 +3,13 @@
 use {
     crate::{error::RecordError, instruction::RecordInstruction, state::RecordData},
     solana_account_info::{next_account_info, AccountInfo},
+    solana_address::Address,
     solana_msg::msg,
     solana_program_error::{ProgramError, ProgramResult},
     solana_program_pack::IsInitialized,
-    solana_pubkey::Pubkey,
 };
 
-fn check_authority(authority_info: &AccountInfo, expected_authority: &Pubkey) -> ProgramResult {
+fn check_authority(authority_info: &AccountInfo, expected_authority: &Address) -> ProgramResult {
     if expected_authority != authority_info.key {
         msg!("Incorrect record authority provided");
         return Err(RecordError::IncorrectAuthority.into());
@@ -23,7 +23,7 @@ fn check_authority(authority_info: &AccountInfo, expected_authority: &Pubkey) ->
 
 /// Instruction processor
 pub fn process_instruction(
-    _program_id: &Pubkey,
+    _program_id: &Address,
     accounts: &[AccountInfo],
     input: &[u8],
 ) -> ProgramResult {

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -1,8 +1,8 @@
 //! Program state
 use {
     bytemuck::{Pod, Zeroable},
+    solana_address::Address,
     solana_program_pack::IsInitialized,
-    solana_pubkey::Pubkey,
 };
 
 /// Header type for recorded account data
@@ -13,7 +13,7 @@ pub struct RecordData {
     pub version: u8,
 
     /// The account allowed to update the data
-    pub authority: Pubkey,
+    pub authority: Address,
 }
 
 impl RecordData {
@@ -37,20 +37,20 @@ pub(crate) mod tests {
 
     /// Version for tests
     pub const TEST_VERSION: u8 = 1;
-    /// Pubkey for tests
-    pub const TEST_PUBKEY: Pubkey = Pubkey::new_from_array([100; 32]);
+    /// Address for tests
+    pub const TEST_ADDRESS: Address = Address::new_from_array([100; 32]);
     /// Bytes for tests
     pub const TEST_BYTES: [u8; 8] = [42; 8];
     /// `RecordData` for tests
     pub const TEST_RECORD_DATA: RecordData = RecordData {
         version: TEST_VERSION,
-        authority: TEST_PUBKEY,
+        authority: TEST_ADDRESS,
     };
 
     #[test]
     fn serialize_data() {
         let mut expected = vec![TEST_VERSION];
-        expected.extend_from_slice(&TEST_PUBKEY.to_bytes());
+        expected.extend_from_slice(&TEST_ADDRESS.to_bytes());
         assert_eq!(bytemuck::bytes_of(&TEST_RECORD_DATA), expected);
         assert_eq!(
             *bytemuck::try_from_bytes::<RecordData>(&expected).unwrap(),
@@ -61,7 +61,7 @@ pub(crate) mod tests {
     #[test]
     fn deserialize_invalid_slice() {
         let mut expected = vec![TEST_VERSION];
-        expected.extend_from_slice(&TEST_PUBKEY.to_bytes());
+        expected.extend_from_slice(&TEST_ADDRESS.to_bytes());
         expected.extend_from_slice(&TEST_BYTES);
         let err = bytemuck::try_from_bytes::<RecordData>(&expected)
             .map_err(|_| ProgramError::InvalidArgument)

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -1,18 +1,18 @@
 use {
     mollusk_svm::{result::Check, Mollusk},
     solana_account::Account,
+    solana_address::Address,
     solana_instruction::{AccountMeta, Instruction},
     solana_program_error::ProgramError,
-    solana_pubkey::Pubkey,
     solana_rent::Rent,
     solana_system_interface::instruction as system_instruction,
     spl_record::{error::RecordError, id, instruction, state::RecordData},
 };
 
 fn initialize_instructions(
-    payer: &Pubkey,
-    authority: &Pubkey,
-    account: &Pubkey,
+    payer: &Address,
+    authority: &Address,
+    account: &Address,
     data: &[u8],
 ) -> [Instruction; 3] {
     let account_length = std::mem::size_of::<RecordData>()
@@ -35,9 +35,9 @@ fn initialize_instructions(
 fn initialize_success() {
     let mollusk = Mollusk::new(&id(), "spl_record");
 
-    let payer = Pubkey::new_unique();
-    let authority = Pubkey::new_unique();
-    let account = Pubkey::new_unique();
+    let payer = Address::new_unique();
+    let authority = Address::new_unique();
+    let account = Address::new_unique();
     let data = &[111u8; 8];
     let ixs = initialize_instructions(&payer, &authority, &account, data);
     let expected_data = [RecordData::CURRENT_VERSION]
@@ -74,10 +74,10 @@ fn initialize_success() {
 fn initialize_with_seed_success() {
     let mollusk = Mollusk::new(&id(), "spl_record");
 
-    let payer = Pubkey::new_unique();
-    let authority = Pubkey::new_unique();
+    let payer = Address::new_unique();
+    let authority = Address::new_unique();
     let seed = "storage";
-    let account = Pubkey::create_with_seed(&authority, seed, &id()).unwrap();
+    let account = Address::create_with_seed(&authority, seed, &id()).unwrap();
     let data = &[111u8; 8];
     let account_length = std::mem::size_of::<RecordData>()
         .checked_add(data.len())
@@ -129,9 +129,9 @@ fn initialize_with_seed_success() {
 fn initialize_twice_fail() {
     let mollusk = Mollusk::new(&id(), "spl_record");
 
-    let payer = Pubkey::new_unique();
-    let authority = Pubkey::new_unique();
-    let account = Pubkey::new_unique();
+    let payer = Address::new_unique();
+    let authority = Address::new_unique();
+    let account = Address::new_unique();
     let data = &[111u8; 8];
     let mut ixs = initialize_instructions(&payer, &authority, &account, data).to_vec();
     ixs.push(instruction::initialize(&account, &authority));
@@ -165,9 +165,9 @@ fn initialize_twice_fail() {
 fn write_success() {
     let mollusk = Mollusk::new(&id(), "spl_record");
 
-    let payer = Pubkey::new_unique();
-    let authority = Pubkey::new_unique();
-    let account = Pubkey::new_unique();
+    let payer = Address::new_unique();
+    let authority = Address::new_unique();
+    let account = Address::new_unique();
     let data = &[111u8; 8];
     let new_data = &[200u8; 8];
     let mut ixs = initialize_instructions(&payer, &authority, &account, data).to_vec();
@@ -206,10 +206,10 @@ fn write_success() {
 #[test]
 fn write_fail_wrong_authority() {
     let mollusk = Mollusk::new(&id(), "spl_record");
-    let payer = Pubkey::new_unique();
-    let authority = Pubkey::new_unique();
-    let wrong_authority = Pubkey::new_unique();
-    let account = Pubkey::new_unique();
+    let payer = Address::new_unique();
+    let authority = Address::new_unique();
+    let wrong_authority = Address::new_unique();
+    let account = Address::new_unique();
     let data = &[111u8; 8];
     let new_data = &[200u8; 8];
     let mut ixs = initialize_instructions(&payer, &authority, &account, data).to_vec();
@@ -246,9 +246,9 @@ fn write_fail_wrong_authority() {
 #[test]
 fn write_fail_unsigned() {
     let mollusk = Mollusk::new(&id(), "spl_record");
-    let payer = Pubkey::new_unique();
-    let authority = Pubkey::new_unique();
-    let account = Pubkey::new_unique();
+    let payer = Address::new_unique();
+    let authority = Address::new_unique();
+    let account = Address::new_unique();
     let data = &[111u8; 8];
     let mut ixs = initialize_instructions(&payer, &authority, &account, data).to_vec();
     ixs.push(Instruction {
@@ -288,10 +288,10 @@ fn write_fail_unsigned() {
 #[test]
 fn close_account_success() {
     let mollusk = Mollusk::new(&id(), "spl_record");
-    let payer = Pubkey::new_unique();
-    let authority = Pubkey::new_unique();
-    let recipient = Pubkey::new_unique();
-    let account = Pubkey::new_unique();
+    let payer = Address::new_unique();
+    let authority = Address::new_unique();
+    let recipient = Address::new_unique();
+    let account = Address::new_unique();
     let data = &[111u8; 8];
     let account_length = std::mem::size_of::<RecordData>()
         .checked_add(data.len())
@@ -330,11 +330,11 @@ fn close_account_success() {
 #[test]
 fn close_account_fail_wrong_authority() {
     let mollusk = Mollusk::new(&id(), "spl_record");
-    let payer = Pubkey::new_unique();
-    let authority = Pubkey::new_unique();
-    let wrong_authority = Pubkey::new_unique();
-    let recipient = Pubkey::new_unique();
-    let account = Pubkey::new_unique();
+    let payer = Address::new_unique();
+    let authority = Address::new_unique();
+    let wrong_authority = Address::new_unique();
+    let recipient = Address::new_unique();
+    let account = Address::new_unique();
     let data = &[111u8; 8];
     let mut ixs = initialize_instructions(&payer, &authority, &account, data).to_vec();
     ixs.push(instruction::close_account(
@@ -375,10 +375,10 @@ fn close_account_fail_wrong_authority() {
 #[test]
 fn close_account_fail_unsigned() {
     let mollusk = Mollusk::new(&id(), "spl_record");
-    let payer = Pubkey::new_unique();
-    let authority = Pubkey::new_unique();
-    let recipient = Pubkey::new_unique();
-    let account = Pubkey::new_unique();
+    let payer = Address::new_unique();
+    let authority = Address::new_unique();
+    let recipient = Address::new_unique();
+    let account = Address::new_unique();
     let data = &[111u8; 8];
     let mut ixs = initialize_instructions(&payer, &authority, &account, data).to_vec();
     ixs.push(Instruction {
@@ -421,10 +421,10 @@ fn close_account_fail_unsigned() {
 fn set_authority_success() {
     let mollusk = Mollusk::new(&id(), "spl_record");
 
-    let payer = Pubkey::new_unique();
-    let authority = Pubkey::new_unique();
-    let new_authority = Pubkey::new_unique();
-    let account = Pubkey::new_unique();
+    let payer = Address::new_unique();
+    let authority = Address::new_unique();
+    let new_authority = Address::new_unique();
+    let account = Address::new_unique();
     let data = &[111u8; 8];
     let mut ixs = initialize_instructions(&payer, &authority, &account, data).to_vec();
     ixs.push(instruction::set_authority(
@@ -467,11 +467,11 @@ fn set_authority_success() {
 #[test]
 fn set_authority_fail_wrong_authority() {
     let mollusk = Mollusk::new(&id(), "spl_record");
-    let payer = Pubkey::new_unique();
-    let authority = Pubkey::new_unique();
-    let wrong_authority = Pubkey::new_unique();
-    let new_authority = Pubkey::new_unique();
-    let account = Pubkey::new_unique();
+    let payer = Address::new_unique();
+    let authority = Address::new_unique();
+    let wrong_authority = Address::new_unique();
+    let new_authority = Address::new_unique();
+    let account = Address::new_unique();
     let data = &[111u8; 8];
     let mut ixs = initialize_instructions(&payer, &authority, &account, data).to_vec();
     ixs.push(instruction::set_authority(
@@ -512,10 +512,10 @@ fn set_authority_fail_wrong_authority() {
 #[test]
 fn set_authority_fail_unsigned() {
     let mollusk = Mollusk::new(&id(), "spl_record");
-    let payer = Pubkey::new_unique();
-    let authority = Pubkey::new_unique();
-    let new_authority = Pubkey::new_unique();
-    let account = Pubkey::new_unique();
+    let payer = Address::new_unique();
+    let authority = Address::new_unique();
+    let new_authority = Address::new_unique();
+    let account = Address::new_unique();
     let data = &[111u8; 8];
     let mut ixs = initialize_instructions(&payer, &authority, &account, data).to_vec();
     ixs.push(Instruction {
@@ -557,9 +557,9 @@ fn set_authority_fail_unsigned() {
 #[test]
 fn reallocate_success() {
     let mollusk = Mollusk::new(&id(), "spl_record");
-    let payer = Pubkey::new_unique();
-    let authority = Pubkey::new_unique();
-    let account = Pubkey::new_unique();
+    let payer = Address::new_unique();
+    let authority = Address::new_unique();
+    let account = Address::new_unique();
     let data = &[111u8; 8];
     let new_data_length = 16u64;
 
@@ -626,10 +626,10 @@ fn reallocate_success() {
 #[test]
 fn reallocate_fail_wrong_authority() {
     let mollusk = Mollusk::new(&id(), "spl_record");
-    let payer = Pubkey::new_unique();
-    let authority = Pubkey::new_unique();
-    let wrong_authority = Pubkey::new_unique();
-    let account = Pubkey::new_unique();
+    let payer = Address::new_unique();
+    let authority = Address::new_unique();
+    let wrong_authority = Address::new_unique();
+    let account = Address::new_unique();
     let data = &[111u8; 8];
     let new_data_length = 16u64;
     let delta_account_data_length = new_data_length.saturating_sub(data.len() as u64);
@@ -679,9 +679,9 @@ fn reallocate_fail_wrong_authority() {
 #[test]
 fn reallocate_fail_unsigned() {
     let mollusk = Mollusk::new(&id(), "spl_record");
-    let payer = Pubkey::new_unique();
-    let authority = Pubkey::new_unique();
-    let account = Pubkey::new_unique();
+    let payer = Address::new_unique();
+    let authority = Address::new_unique();
+    let account = Address::new_unique();
     let data = &[111u8; 8];
     let new_data_length = 16u64;
     let delta_account_data_length = new_data_length.saturating_sub(data.len() as u64);


### PR DESCRIPTION
#### Problem

The newest SDK crates are out, but the record program isn't using them.

#### Summary of changes

Bump everything to the newest versions. At the same time, switch from solana-pubkey to solana-address.